### PR TITLE
Add the label to the command' metavar

### DIFF
--- a/x-optparse/src/X/Options/Applicative.hs
+++ b/x-optparse/src/X/Options/Applicative.hs
@@ -38,7 +38,7 @@ textRead = fmap T.pack str
 --   slightly cleaner way
 command' :: String -> String -> Parser a -> Mod CommandFields a
 command' label description parser =
-  command label (info (parser <**> helper) (progDesc description))
+  command label (info (parser <**> helper) (progDesc description)) <> metavar label
 
 -- | Dispatch multi-mode programs with appropriate helper to make the
 --   default behaviour a bit better.


### PR DESCRIPTION
I noticed that `sanction` was

```
Usage: sanction ((-v|--version) | [--region REGION] (COMMAND | COMMAND | COMMAND))
```

Changing this it now looks like:

```
Usage: sanction ((-v|--version) | [--region REGION] (commission | decommission | status))
```

Not 100% this is the right thing to do - is there confusion that they're commands?
