### PR TITLE
reduceEitherT

### DIFF
--- a/x-either/src/X/Control/Monad/Trans/Either.hs
+++ b/x-either/src/X/Control/Monad/Trans/Either.hs
@@ -9,6 +9,7 @@ module X.Control.Monad.Trans.Either (
   , joinEitherT
   , joinErrors
   , joinErrorsEither
+  , reduceEitherT
   ) where
 
 import           Control.Monad.Trans.Either as X (
@@ -48,6 +49,39 @@ joinEitherT f = mapEitherE (join . first f) . runEitherT
 -- | unify the errors of 2 nested EithersT
 joinErrors :: (Functor m, Monad m) => (x -> z) -> (y -> z) -> EitherT x (EitherT y m) a -> EitherT z m a
 joinErrors f g = joinEitherT g . firstEitherT f
+
+-- |
+-- `joinErrors` results in a cycle of hoists/mapEitherTs and joinErrors to bubble errors up to the top layer of EitherT
+-- before popping it off with a final `runEitherT`, `reduceEitherT` collects the repeated bits in a single function.
+--
+-- example usage:
+--
+-- @
+-- data ErrorBar = ...
+--
+-- data ErrorFoo = FooBar ErrorBar | FooBarBar ErrorBarBar | ...
+--
+-- newtype SomeMonadTransformer1T m a = SomeMonadTransformer1T { run1T :: EitherT ErrorFoo (ReaderT String m) a }
+-- newtype SomeMonadTransformer2T m a = SomeMonadTransformer2T { run2T :: EitherT ErrorBar (ReaderT Int m) a }
+-- newtype SomeMonadTransformer3T m a = SomeMonadTransformer3T { run3T :: EitherT ErrorBarBar m a }
+--
+-- myStackUnwrappingFunctionImagineNoEithers :: String -> Int -> SomeMonadTransformer1T (SomeMonadTransformer2T (SomeMonadTransformer3T m)) a -> m a
+-- myStackUnwrappingFunctionImagineNoEithers s x = run3T . flip runReaderT x . run2T . flip runReaderT s . run1T
+--
+-- myStackUnwrappingFunctionWith :: String -> Int -> SomeMonadTransformer1T (SomeMonadTransformer2T (SomeMonadTransformer3T m)) a -> m (Either ErrorFoo a)
+-- myStackUnwrappingFunctionWith s x = runEitherT . reduceEitherT FooBarBar (run3T . flip runReaderT x) . reduceEitherT FooBar (run2T . flip runReaderT s) . run1T
+--
+-- myStackUnwrappingFunctionWithout :: String -> Int -> SomeMonadTransformer1T (SomeMonadTransformer2T m) a -> m (Either ErrorFoo a)
+-- myStackUnwrappingFunctionWithout s x = runEitherT . joinEitherT FooBarBar . hoistEitherT (run3T . flip runReaderT x) . joinEitherT FooBar . hoistEitherT (run2T . flip runReaderT s) . run1T
+-- @
+--
+reduceEitherT
+  :: (Functor n, Monad n)
+  => (e' -> e)
+  -> (forall a. m a -> EitherT e' n a)
+  -> EitherT e m b
+  -> EitherT e n b
+reduceEitherT embedError f = joinEitherT embedError . hoistEitherT f
 
 -- | unify the errors of 2 nested EithersT with an Either e f
 --   note that the "inner" monad error (like a network error) becomes the Left error


### PR DESCRIPTION
`joinErrors` is good but wanted to make the `hoist -> join` cycle a little more concise, i think they're going to appear consecutively often enough for us to consider it a concept.

@etorreborre 

--------

Reminder for myself:

TODO:

- [x] flip the args
- [x] use `joinEitherT`
- [ ] maybe example usage in doc