### PR TITLE
Break joinErrors up in to simpler parts

### DIFF
--- a/x-either/src/X/Control/Monad/Trans/Either.hs
+++ b/x-either/src/X/Control/Monad/Trans/Either.hs
@@ -5,6 +5,8 @@ module X.Control.Monad.Trans.Either (
   , secondEitherT
   , eitherTFromMaybe
   , hoistEitherT
+  , mapEitherE
+  , joinEitherT
   , joinErrors
   , joinErrorsEither
   ) where
@@ -37,9 +39,15 @@ eitherTFromMaybe e =
 hoistEitherT :: (forall t. m t -> n t) -> EitherT e m a -> EitherT e n a
 hoistEitherT f = EitherT . f . runEitherT
 
+mapEitherE :: Functor m => (Either x a -> Either y b) -> EitherT x m a -> EitherT y m b
+mapEitherE f = mapEitherT (fmap f)
+
+joinEitherT :: Functor m => (y -> x) -> EitherT x (EitherT y m) a -> EitherT x m a
+joinEitherT f = mapEitherE (join . first f) . runEitherT
+
 -- | unify the errors of 2 nested EithersT
-joinErrors :: (Functor m, Monad m) => (e -> g) -> (f -> g) -> EitherT e (EitherT f m) a -> EitherT g m a
-joinErrors g1 g2 = mapEitherT (fmap (join . bimap g2 (first g1))) . runEitherT
+joinErrors :: (Functor m, Monad m) => (x -> z) -> (y -> z) -> EitherT x (EitherT y m) a -> EitherT z m a
+joinErrors f g = joinEitherT g . firstEitherT f
 
 -- | unify the errors of 2 nested EithersT with an Either e f
 --   note that the "inner" monad error (like a network error) becomes the Left error


### PR DESCRIPTION
I spent a bit of time staring at `joinErrors` yesterday night trying to grok what it was doing.

Breaking it down like this helped me understand it a bit better.

Not sure if this is a useful change, what do people think?