### PR TITLE
Update x-optparse.cabal

### DIFF
--- a/x-optparse/x-optparse.cabal
+++ b/x-optparse/x-optparse.cabal
@@ -13,7 +13,7 @@ description:           x-optparse.
 library
   build-depends:
                        base                            >= 3          && < 5
-                     , attoparsec                      == 0.12.*
+                     , attoparsec                      >= 0.11       && < 0.13
                      , either                          >= 4.3        && < 4.5
                      , optparse-applicative            == 0.12.*
                      , text                            == 1.2.*

--- a/x-optparse/x-optparse.cabal
+++ b/x-optparse/x-optparse.cabal
@@ -13,9 +13,9 @@ description:           x-optparse.
 library
   build-depends:
                        base                            >= 3          && < 5
-                     , attoparsec                      >= 0.11       && < 0.13
+                     , attoparsec                      == 0.12.*
                      , either                          >= 4.3        && < 4.5
-                     , optparse-applicative            == 0.12.*
+                     , optparse-applicative            >= 0.11       && < 0.13
                      , text                            == 1.2.*
                      , transformers                    >= 0.3        && < 0.5
 


### PR DESCRIPTION
I can't see any reason why this can't keep the bounds inclusive of the current in use version. If we don't do this we effectively have to update 50+ cli's in unison which is far from ideal.

Fixes #52 