### PR TITLE
Set a larger upper value for bifunctors to make it compatible with p

### DIFF
--- a/x-either/x-either.cabal
+++ b/x-either/x-either.cabal
@@ -13,7 +13,7 @@ description:           x-either.
 library
   build-depends:
                           base                        >= 4.6        && < 5
-                        , bifunctors                  >= 4.2        && < 5
+                        , bifunctors                  >= 4.2        && <= 5
                         , either                      >= 4.3        && < 4.5
 
   ghc-options:


### PR DESCRIPTION
It seems to me that we need to make it compatible with the [current state of `p`](https://github.com/ambiata/p/blob/master/p.cabal#L18).