### PR TITLE
Generic version of Show which doesn't contain record labels

### DIFF
--- a/framework/mafia
+++ b/framework/mafia
@@ -26,16 +26,23 @@ run_upgrade () {
 
   trap clean_up EXIT
 
+  MAFIA_CUR="$0"
+
+  if [ -L "$MAFIA_CUR" ]; then
+    echo 'Refusing to overwrite a symlink; run `upgrade` from the canonical path.' >&2
+    exit 1
+  fi
+
   echo "Checking for a new version of mafia ..."
   fetch_latest > $MAFIA_TEMP
 
   LATEST_VERSION=$(latest_version)
   echo "# Version: $LATEST_VERSION" >> $MAFIA_TEMP
 
-  if ! cmp ./mafia $MAFIA_TEMP >/dev/null 2>&1; then
+  if ! cmp $MAFIA_CUR $MAFIA_TEMP >/dev/null 2>&1; then
+    mv $MAFIA_TEMP $MAFIA_CUR
+    chmod +x $MAFIA_CUR
     echo "New version found and upgraded. You can now commit it to your git repo."
-    mv $MAFIA_TEMP ./mafia
-    chmod +x ./mafia
   else
     echo "You have latest mafia."
   fi
@@ -103,4 +110,4 @@ case "$MODE" in
 upgrade) shift; run_upgrade "$@" ;;
 *) exec_mafia "$@"
 esac
-# Version: 81930dba49292eca959d7e0eb7ea9d61a773290f
+# Version: 92881411b204a00b11d8a26117bd9244fdb8e4d4

--- a/x-show/.ghci
+++ b/x-show/.ghci
@@ -1,0 +1,1 @@
+../framework/ghci

--- a/x-show/ambiata-x-show.cabal
+++ b/x-show/ambiata-x-show.cabal
@@ -1,0 +1,43 @@
+name:                  ambiata-x-show
+version:               0.0.1
+license:               AllRightsReserved
+author:                Ambiata <info@ambiata.com>
+maintainer:            Ambiata <info@ambiata.com>
+copyright:             (c) 2015 Ambiata.
+synopsis:              ambiata-x-show.
+category:              Prelude
+cabal-version:         >= 1.8
+build-type:            Simple
+description:           ambiata-x-show.
+
+library
+  build-depends:
+                       base                            >= 4.6        && < 5
+                     , ambiata-p
+
+  ghc-options:
+                       -Wall
+
+  hs-source-dirs:
+                       src
+
+
+  exposed-modules:
+                       X.Text.Show
+
+test-suite test
+  type:                exitcode-stdio-1.0
+
+  main-is:             test.hs
+
+  ghc-options:         -Wall -threaded -O2
+
+  hs-source-dirs:
+                       test
+
+  build-depends:       base
+                     , ambiata-disorder-core
+                     , ambiata-p
+                     , ambiata-x-show
+                     , QuickCheck                      == 2.8.*
+                     , quickcheck-instances            == 0.3.*

--- a/x-show/mafia
+++ b/x-show/mafia
@@ -1,0 +1,1 @@
+../framework/mafia

--- a/x-show/src/X/Text/Show.hs
+++ b/x-show/src/X/Text/Show.hs
@@ -1,0 +1,117 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators #-}
+module X.Text.Show (
+    gshowsPrec
+  ) where
+
+import           Data.String (String)
+
+import           GHC.Generics ((:*:)(..), (:+:)(..))
+import           GHC.Generics (Constructor(..))
+import           GHC.Generics (Generic(..), Rep, Fixity(..))
+import           GHC.Generics (U1(..), K1(..), M1(..), D, C, S)
+import           GHC.Show (appPrec, appPrec1)
+
+import           P
+
+
+-- | This implements a generic version of 'Text.Show.showsPrec' which omits
+--   labels for record names when rendering constructors.
+gshowsPrec :: (Generic a, GShow (Rep a)) => Int -> a -> ShowS
+gshowsPrec n = gshowsPrec' ConPrefix n . from
+
+
+data ConType = ConPrefix | ConInfix String
+
+class GShow f where
+  gshowsPrec' :: ConType -> Int -> f a -> ShowS
+
+  isNullary :: f a -> Bool
+  isNullary _ =
+    False
+
+instance GShow U1 where
+  gshowsPrec' _ _ U1 =
+    id
+
+  isNullary _ =
+    True
+
+instance Show c => GShow (K1 i c) where
+  gshowsPrec' _ n (K1 a) =
+    showsPrec n a
+
+instance (GShow a, Constructor c) => GShow (M1 C c a) where
+  gshowsPrec' _ n c@(M1 x) =
+    let
+      fixity =
+        conFixity c
+
+      t =
+        case fixity of
+          Prefix ->
+            ConPrefix
+          Infix _ _ ->
+            ConInfix $ conName c
+    in
+      case fixity of
+        Prefix ->
+          showParen (n > appPrec && not (isNullary x)) $
+            showString (conName c) .
+            if isNullary x then id else showChar ' ' .
+            gshowsPrec' t appPrec1 x
+        Infix _ m ->
+          showParen (n > m) $ gshowsPrec' t (m+1) x
+
+instance GShow a => GShow (M1 S s a) where
+  gshowsPrec' t n (M1 x) =
+    gshowsPrec' t n x
+
+  isNullary (M1 x) =
+    isNullary x
+
+instance (GShow a) => GShow (M1 D d a) where
+  gshowsPrec' t n (M1 x) =
+    gshowsPrec' t n x
+
+instance (GShow a, GShow b) => GShow (a :+: b) where
+  gshowsPrec' t n = \case
+    L1 x ->
+      gshowsPrec' t n x
+    R1 x ->
+      gshowsPrec' t n x
+
+instance (GShow a, GShow b) => GShow (a :*: b) where
+  gshowsPrec' t n (a :*: b) =
+    case t of
+      ConPrefix ->
+        gshowsPrec' t n a .
+        showChar ' ' .
+        gshowsPrec' t n b
+      ConInfix s ->
+        let
+          isInfixTypeCon = \case
+            ':':_ ->
+              True
+            _ ->
+              False
+
+          showBacktick =
+            if isInfixTypeCon s then
+              id
+            else
+              showChar '`'
+        in
+          gshowsPrec' t n a .
+          showChar ' ' .
+          showBacktick .
+          showString s .
+          showBacktick .
+          showChar ' ' .
+          gshowsPrec' t n b

--- a/x-show/test/Test/X/Text/Show.hs
+++ b/x-show/test/Test/X/Text/Show.hs
@@ -1,0 +1,107 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Test.X.Text.Show where
+
+import           Data.String (String)
+import qualified Data.List as List
+
+import           GHC.Generics (Generic)
+
+import           P
+
+import           System.IO (IO)
+
+import           Test.QuickCheck
+import           Test.QuickCheck.Instances ()
+
+import           X.Text.Show
+
+
+data Foo =
+    Foo
+  | Bar Bar
+  | Baz Baz
+    deriving (Generic)
+
+newtype Bar =
+  MkBar {
+      unBar :: Int
+    } deriving (Generic)
+
+data Baz =
+  MkBaz {
+      bazInt :: Int
+    , bazDouble :: Double
+    , bazBar :: Bar
+    } deriving (Generic)
+
+instance Show Foo where
+  showsPrec =
+    gshowsPrec
+
+instance Show Bar where
+  showsPrec =
+    gshowsPrec
+
+instance Show Baz where
+  showsPrec =
+    gshowsPrec
+
+instance Arbitrary Foo where
+  arbitrary =
+    oneof [
+        pure Foo
+      , Bar <$> arbitrary
+      , Baz <$> arbitrary
+      ]
+
+  shrink =
+    genericShrink
+
+instance Arbitrary Bar where
+  arbitrary =
+    MkBar <$> arbitrary
+
+  shrink =
+    genericShrink
+
+instance Arbitrary Baz where
+  arbitrary =
+    MkBaz <$> arbitrary <*> arbitrary <*> arbitrary
+
+  shrink =
+    genericShrink
+
+prop_no_equals :: Foo -> Property
+prop_no_equals =
+  mustNotContain "="
+
+prop_no_lbrace :: Foo -> Property
+prop_no_lbrace =
+  mustNotContain "{"
+
+prop_no_rbrace :: Foo -> Property
+prop_no_rbrace =
+  mustNotContain "}"
+
+mustNotContain :: Show a => String -> a -> Property
+mustNotContain needle x =
+  let
+    s =
+      show x
+
+    msg =
+      "\n  Derived show instance contained traces of record labels." <>
+      "\n" <>
+      "\n  Found " <> show needle <> " in show output:" <>
+      "\n" <>
+      "\n    " <> s
+  in
+    counterexample msg . property . not $
+      List.isInfixOf needle s
+
+return []
+tests :: IO Bool
+tests = $quickCheckAll

--- a/x-show/test/test.hs
+++ b/x-show/test/test.hs
@@ -1,0 +1,9 @@
+import           Disorder.Core.Main
+
+import qualified Test.X.Text.Show
+
+main :: IO ()
+main =
+  disorderMain [
+      Test.X.Text.Show.tests
+    ]


### PR DESCRIPTION
This will show `newtype Foo = Foo { unFoo :: Int }` as `Foo 0` rather than `Foo { unFoo = 0 }` which can make understanding printouts with lots of newtypes a lot more pleasant, while still allowing you to paste the resulting output in to your editor or the repl.

To use it, you just derive your type from `Generic`, then instead of deriving `Show` as normal, you do it like this:
```hs
{-# LANGUAGE DeriveGeneric #-}

import           GHC.Generics (Generic)

import           X.Text.Show (gshowsPrec)

newtype Foo =
  Foo {
      unFoo :: Int
    } deriving (Generic)

instance Show Foo where
  showsPrec =
    gshowsPrec
```

I wouldn't use this for all record types, just ones where the labels don't offer any useful additional context.