### PR TITLE
Add newtype Disaster wrapper for SomeException

### DIFF
--- a/x-exception/src/X/Control/Monad/Catch.hs
+++ b/x-exception/src/X/Control/Monad/Catch.hs
@@ -2,20 +2,51 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE RankNTypes #-}
 module X.Control.Monad.Catch (
-    bracketF
+    Disaster(..)
+  , bracketF
   , hushM
   ) where
 
 import           Control.Monad (return, liftM)
 import           Control.Monad.Catch (catchAll, throwM, handle)
-import           Control.Monad.Catch (Exception(..), SomeException)
+import           Control.Monad.Catch (Exception(..), SomeException(..))
 import           Control.Monad.Catch (MonadCatch(..), MonadMask(..))
 
-import           Data.Bool (Bool)
+import           Data.Bool (Bool(..))
 import           Data.Either (Either(..), either)
-import           Data.Function (($), const, id)
+import           Data.Eq (Eq(..))
+import           Data.Function (($), (.), const, id)
 import           Data.Maybe (Maybe(..))
+import           Data.Ord (Ord(..))
+import           Data.Typeable (typeOf)
 
+import           GHC.Show (appPrec)
+
+import           Text.Show (Show(..), showParen, showString, showChar)
+
+
+-- | Newtype wrapper for 'SomeException' which provides an 'Eq' instance which
+--   says no two disasters are equal. It also provides a 'Show' instance
+--   containing only valid Haskell 98 tokens.
+--
+--   This is useful for embedding 'SomeException' in a sensible error type that
+--   has equality for all the other cases.
+newtype Disaster =
+  Disaster {
+      unDisaster :: SomeException
+    }
+
+instance Eq Disaster where
+  (==) _ _ =
+    False
+
+instance Show Disaster where
+  showsPrec prec (Disaster (SomeException e)) =
+    showParen (prec > appPrec) $
+      showString "Disaster " .
+      showsPrec 11 (typeOf e) .
+      showChar ' ' .
+      showsPrec 11 (show e)
 
 data BracketResult a =
     BracketOk a


### PR DESCRIPTION
This is possibly a bit controversial :)

The idea behind `Disaster` is that you sometimes have an error case which happens when some unknown exception is thrown and it should never really happen. Handling this means that your entire error type can't implement `Eq`, which is quite inconvenient.

The reason I went for saying that no two exceptions are the same is that I think this is the safest approach for something like this, an alternative might be comparing strings :worried: 

/cc  @nhibberd @markhibberd @charleso 