### PR TITLE
x-vector: mapMaybe, imapMaybe, mapMaybeM, imapMaybeM

### DIFF
--- a/x-vector/.ghci
+++ b/x-vector/.ghci
@@ -1,0 +1,1 @@
+../framework/ghci

--- a/x-vector/ambiata-x-vector.cabal
+++ b/x-vector/ambiata-x-vector.cabal
@@ -1,0 +1,49 @@
+name:                  ambiata-x-vector
+version:               0.0.1
+license:               AllRightsReserved
+author:                Ambiata <info@ambiata.com>
+maintainer:            Ambiata <info@ambiata.com>
+copyright:             (c) 2015 Ambiata.
+synopsis:              ambiata-x-vector.
+category:              Prelude
+cabal-version:         >= 1.8
+build-type:            Simple
+description:           ambiata-x-vector.
+
+library
+  build-depends:
+                       base                            >= 4.6        && < 5
+                     , ambiata-p
+                     , vector                          >= 0.10       && < 0.12
+
+  ghc-options:
+                       -Wall
+
+  hs-source-dirs:
+                       src
+
+
+  exposed-modules:
+                       X.Data.Vector
+                       X.Data.Vector.Generic
+                       X.Data.Vector.Primitive
+                       X.Data.Vector.Storable
+                       X.Data.Vector.Unboxed
+
+test-suite test
+  type:                exitcode-stdio-1.0
+
+  main-is:             test.hs
+
+  ghc-options:         -Wall -threaded -O2
+
+  hs-source-dirs:
+                       test
+
+  build-depends:       base
+                     , ambiata-disorder-core
+                     , ambiata-p
+                     , ambiata-x-vector
+                     , QuickCheck                      == 2.8.*
+                     , quickcheck-instances            == 0.3.*
+                     , transformers                    >= 0.4        && < 0.6

--- a/x-vector/mafia
+++ b/x-vector/mafia
@@ -1,0 +1,1 @@
+../framework/mafia

--- a/x-vector/src/X/Data/Vector.hs
+++ b/x-vector/src/X/Data/Vector.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+module X.Data.Vector (
+    module Boxed
+
+  -- * Elementwise operations
+
+  -- ** Mapping
+  , mapMaybe
+  , imapMaybe
+
+  -- ** Monadic mapping
+  , mapMaybeM
+  , imapMaybeM
+  ) where
+
+import           Data.Vector as Boxed
+
+import           P hiding (mapMaybe)
+
+import qualified X.Data.Vector.Generic as Generic
+
+
+mapMaybe :: (a -> Maybe b) -> Vector a -> Vector b
+mapMaybe =
+  Generic.mapMaybe
+{-# INLINE mapMaybe #-}
+
+imapMaybe :: (Int -> a -> Maybe b) -> Vector a -> Vector b
+imapMaybe =
+  Generic.imapMaybe
+{-# INLINE imapMaybe #-}
+
+mapMaybeM :: Monad m => (a -> m (Maybe b)) -> Vector a -> m (Vector b)
+mapMaybeM =
+  Generic.mapMaybeM
+{-# INLINE mapMaybeM #-}
+
+imapMaybeM :: Monad m => (Int -> a -> m (Maybe b)) -> Vector a -> m (Vector b)
+imapMaybeM =
+  Generic.imapMaybeM
+{-# INLINE imapMaybeM #-}

--- a/x-vector/src/X/Data/Vector/Generic.hs
+++ b/x-vector/src/X/Data/Vector/Generic.hs
@@ -1,0 +1,108 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+module X.Data.Vector.Generic (
+    module Generic
+
+  -- * Elementwise operations
+
+  -- ** Mapping
+  , mapMaybe
+  , imapMaybe
+
+  -- ** Monadic mapping
+  , mapMaybeM
+  , imapMaybeM
+
+  -- * Fusion support
+
+  -- ** Conversion to/from bundles
+  , unstreamM
+  ) where
+
+import           Data.Vector.Fusion.Bundle (Step(..))
+import qualified Data.Vector.Fusion.Bundle as Bundle
+import           Data.Vector.Fusion.Bundle.Monadic (Bundle(..))
+import qualified Data.Vector.Fusion.Bundle.Monadic as MBundle
+import           Data.Vector.Fusion.Bundle.Size (toMax)
+import           Data.Vector.Fusion.Stream.Monadic (Stream(..))
+import qualified Data.Vector.Fusion.Stream.Monadic as Stream
+
+import           Data.Vector.Generic as Generic
+
+import           P hiding (mapMaybe)
+
+
+mapMaybe :: (Vector v a, Vector v b) => (a -> Maybe b) -> v a -> v b
+mapMaybe f =
+  unstream .
+  Bundle.inplace (mapMaybeStream (return . f)) toMax .
+  stream
+{-# INLINE mapMaybe #-}
+
+imapMaybe :: (Vector v a, Vector v b) => (Int -> a -> Maybe b) -> v a -> v b
+imapMaybe f =
+  unstream .
+  Bundle.inplace (mapMaybeStream (return . uncurry f) . Stream.indexed) toMax .
+  stream
+{-# INLINE imapMaybe #-}
+
+mapMaybeM :: Monad m => (Vector v a, Vector v b) => (a -> m (Maybe b)) -> v a -> m (v b)
+mapMaybeM f =
+  unstreamM .
+  mapMaybeBundle f .
+  Bundle.lift .
+  stream
+{-# INLINE mapMaybeM #-}
+
+imapMaybeM :: Monad m => (Vector v a, Vector v b) => (Int -> a -> m (Maybe b)) -> v a -> m (v b)
+imapMaybeM f =
+  unstreamM .
+  imapMaybeBundle f .
+  Bundle.lift .
+  stream
+{-# INLINE imapMaybeM #-}
+
+mapMaybeBundle :: Monad m => (a -> m (Maybe b)) -> Bundle m v a -> Bundle m v b
+mapMaybeBundle f Bundle {sElems = s, sSize = n} =
+  MBundle.fromStream (mapMaybeStream f s) (toMax n)
+{-# INLINE mapMaybeBundle #-}
+
+imapMaybeBundle :: Monad m => (Int -> a -> m (Maybe b)) -> Bundle m v a -> Bundle m v b
+imapMaybeBundle f Bundle {sElems = s, sSize = n} =
+  MBundle.fromStream (mapMaybeStream (uncurry f) $ Stream.indexed s) (toMax n)
+{-# INLINE imapMaybeBundle #-}
+
+-- include/vector.h
+#define INLINE_FUSED INLINE [1]
+#define INLINE_INNER INLINE [0]
+
+mapMaybeStream :: Monad m => (a -> m (Maybe b)) -> Stream m a -> Stream m b
+mapMaybeStream f (Stream step t) =
+  let
+    step' s = do
+      r <- step s
+      case r of
+        Yield x s' -> do
+          mb <- f x
+          return $
+            case mb of
+              Nothing ->
+                Skip s'
+              Just y ->
+                Yield y s'
+        Skip s' ->
+          return $ Skip s'
+        Done ->
+          return $ Done
+    {-# INLINE_INNER step' #-}
+  in
+    Stream step' t
+{-# INLINE_FUSED mapMaybeStream #-}
+
+-- Not exported by Data.Vector.Generic
+unstreamM :: (Monad m, Vector v a) => Bundle m u a -> m (v a)
+unstreamM s = do
+  xs <- MBundle.toList s
+  return $ unstream $ Bundle.unsafeFromList (MBundle.size s) xs
+{-# INLINE_FUSED unstreamM #-}

--- a/x-vector/src/X/Data/Vector/Primitive.hs
+++ b/x-vector/src/X/Data/Vector/Primitive.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+module X.Data.Vector.Primitive (
+    module Primitive
+
+  -- * Elementwise operations
+
+  -- ** Mapping
+  , mapMaybe
+  , imapMaybe
+
+  -- ** Monadic mapping
+  , mapMaybeM
+  , imapMaybeM
+  ) where
+
+import           Data.Vector.Primitive as Primitive
+
+import           P hiding (mapMaybe)
+
+import qualified X.Data.Vector.Generic as Generic
+
+
+mapMaybe :: (Prim a, Prim b) => (a -> Maybe b) -> Vector a -> Vector b
+mapMaybe =
+  Generic.mapMaybe
+{-# INLINE mapMaybe #-}
+
+imapMaybe :: (Prim a, Prim b) => (Int -> a -> Maybe b) -> Vector a -> Vector b
+imapMaybe =
+  Generic.imapMaybe
+{-# INLINE imapMaybe #-}
+
+mapMaybeM :: (Monad m, Prim a, Prim b) => (a -> m (Maybe b)) -> Vector a -> m (Vector b)
+mapMaybeM =
+  Generic.mapMaybeM
+{-# INLINE mapMaybeM #-}
+
+imapMaybeM :: (Monad m, Prim a, Prim b) => (Int -> a -> m (Maybe b)) -> Vector a -> m (Vector b)
+imapMaybeM =
+  Generic.imapMaybeM
+{-# INLINE imapMaybeM #-}

--- a/x-vector/src/X/Data/Vector/Storable.hs
+++ b/x-vector/src/X/Data/Vector/Storable.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+module X.Data.Vector.Storable (
+    module Storable
+
+  -- * Elementwise operations
+
+  -- ** Mapping
+  , mapMaybe
+  , imapMaybe
+
+  -- ** Monadic mapping
+  , mapMaybeM
+  , imapMaybeM
+  ) where
+
+import           Data.Vector.Storable as Storable
+
+import           P hiding (mapMaybe)
+
+import qualified X.Data.Vector.Generic as Generic
+
+
+mapMaybe :: (Storable a, Storable b) => (a -> Maybe b) -> Vector a -> Vector b
+mapMaybe =
+  Generic.mapMaybe
+{-# INLINE mapMaybe #-}
+
+imapMaybe :: (Storable a, Storable b) => (Int -> a -> Maybe b) -> Vector a -> Vector b
+imapMaybe =
+  Generic.imapMaybe
+{-# INLINE imapMaybe #-}
+
+mapMaybeM :: (Monad m, Storable a, Storable b) => (a -> m (Maybe b)) -> Vector a -> m (Vector b)
+mapMaybeM =
+  Generic.mapMaybeM
+{-# INLINE mapMaybeM #-}
+
+imapMaybeM :: (Monad m, Storable a, Storable b) => (Int -> a -> m (Maybe b)) -> Vector a -> m (Vector b)
+imapMaybeM =
+  Generic.imapMaybeM
+{-# INLINE imapMaybeM #-}

--- a/x-vector/src/X/Data/Vector/Unboxed.hs
+++ b/x-vector/src/X/Data/Vector/Unboxed.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+module X.Data.Vector.Unboxed (
+    module Unboxed
+
+  -- * Elementwise operations
+
+  -- ** Mapping
+  , mapMaybe
+  , imapMaybe
+
+  -- ** Monadic mapping
+  , mapMaybeM
+  , imapMaybeM
+  ) where
+
+import           Data.Vector.Unboxed as Unboxed
+
+import           P hiding (mapMaybe)
+
+import qualified X.Data.Vector.Generic as Generic
+
+
+mapMaybe :: (Unbox a, Unbox b) => (a -> Maybe b) -> Vector a -> Vector b
+mapMaybe =
+  Generic.mapMaybe
+{-# INLINE mapMaybe #-}
+
+imapMaybe :: (Unbox a, Unbox b) => (Int -> a -> Maybe b) -> Vector a -> Vector b
+imapMaybe =
+  Generic.imapMaybe
+{-# INLINE imapMaybe #-}
+
+mapMaybeM :: (Monad m, Unbox a, Unbox b) => (a -> m (Maybe b)) -> Vector a -> m (Vector b)
+mapMaybeM =
+  Generic.mapMaybeM
+{-# INLINE mapMaybeM #-}
+
+imapMaybeM :: (Monad m, Unbox a, Unbox b) => (Int -> a -> m (Maybe b)) -> Vector a -> m (Vector b)
+imapMaybeM =
+  Generic.imapMaybeM
+{-# INLINE imapMaybeM #-}

--- a/x-vector/test/Test/X/Data/Vector/Generic.hs
+++ b/x-vector/test/Test/X/Data/Vector/Generic.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Test.X.Data.Vector.Generic where
+
+import           Data.Functor.Identity (runIdentity)
+import qualified Data.List as List
+
+import           P
+
+import           System.IO (IO)
+
+import           Test.QuickCheck (Property, (===), quickCheckAll)
+import           Test.QuickCheck.Function (Fun, apply)
+import           Test.QuickCheck.Instances ()
+
+import qualified X.Data.Vector as Boxed
+import qualified X.Data.Vector.Generic as Generic
+
+
+prop_mapMaybe :: Fun Int (Maybe Int) -> [Int] -> Property
+prop_mapMaybe f =
+  equivalent
+    (mapMaybe (apply f))
+    (Generic.mapMaybe (apply f))
+
+prop_mapMaybeM :: Fun Int (Maybe Int) -> [Int] -> Property
+prop_mapMaybeM f =
+  equivalent
+    (mapMaybe (apply f))
+    (runIdentity . Generic.mapMaybeM (pure . apply f))
+
+prop_imapMaybe :: Fun (Int, Int) (Maybe Int) -> [Int] -> Property
+prop_imapMaybe f =
+  equivalent
+    (imapMaybe (curry $ apply f))
+    (Generic.imapMaybe (curry $ apply f))
+
+prop_imapMaybeM :: Fun (Int, Int) (Maybe Int) -> [Int] -> Property
+prop_imapMaybeM f =
+  equivalent
+    (imapMaybe (curry $ apply f))
+    (runIdentity . Generic.imapMaybeM (curry $ pure . apply f))
+
+imapMaybe :: (Int -> a -> Maybe b) -> [a] -> [b]
+imapMaybe f xs =
+  catMaybes $ List.zipWith f [0..] xs
+
+equivalent ::
+  Eq b =>
+  Show b =>
+  ([a] -> [b]) ->
+  (forall v. (Generic.Vector v a, Generic.Vector v b) => v a -> v b) ->
+  [a] ->
+  Property
+equivalent f g xs =
+  f xs === (Boxed.toList . g . Boxed.fromList) xs
+
+return []
+tests :: IO Bool
+tests = $quickCheckAll

--- a/x-vector/test/test.hs
+++ b/x-vector/test/test.hs
@@ -1,0 +1,10 @@
+import           Disorder.Core.Main
+
+import qualified Test.X.Data.Vector.Generic
+
+
+main :: IO ()
+main =
+  disorderMain [
+      Test.X.Data.Vector.Generic.tests
+    ]


### PR DESCRIPTION
This adds the project `x-vector` with support for `mapMaybe`, `imapMaybe`, `mapMaybeM`, `imapMaybeM`.

After this will do `transpose :: Vector (Vector a) -> Vector (Vector a)`

/cc @amosr @tranma @olorin @erikd-ambiata 