### PR TITLE
x-vector: add transpose for vectors

### DIFF
--- a/x-vector/ambiata-x-vector.cabal
+++ b/x-vector/ambiata-x-vector.cabal
@@ -47,3 +47,21 @@ test-suite test
                      , QuickCheck                      == 2.8.*
                      , quickcheck-instances            == 0.3.*
                      , transformers                    >= 0.4        && < 0.6
+
+benchmark bench
+  type:                exitcode-stdio-1.0
+
+  main-is:             bench.hs
+
+  ghc-options:         -Wall -threaded -O2
+
+  hs-source-dirs:
+                       bench
+
+  build-depends:       base
+                     , ambiata-p
+                     , ambiata-x-vector
+                     , containers                      == 0.5.*
+                     , criterion                       == 1.1.*
+                     , deepseq                         >= 1.3 && < 1.5
+                     , transformers                    >= 0.4        && < 0.6

--- a/x-vector/bench/bench.hs
+++ b/x-vector/bench/bench.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+import           Criterion.Main
+import           Criterion.Types
+
+import qualified Data.List as List
+import qualified Data.Map as Map
+import           Data.String (String)
+
+import           P
+
+import           System.IO (IO)
+
+import qualified X.Data.Vector as Boxed
+import qualified X.Data.Vector.Generic as Generic
+import qualified X.Data.Vector.Unboxed as Unboxed
+
+
+main :: IO ()
+main =
+    defaultMainWith config .
+      fmap (uncurry bgroup) .
+      Map.toList .
+      Map.fromListWith (flip mappend) .
+      fmap (second (:[])) $
+      concatMap benchmarks [1000,2000,3000,4000,5000,6000,7000,8000,9000,10000]
+
+config :: Config
+config =
+  defaultConfig {
+      reportFile = Just "dist/build/x-vector-bench.html"
+    , csvFile = Just "dist/build/x-vector-bench.csv"
+    }
+
+benchmarks :: Int -> [(String, Benchmark)]
+benchmarks size =
+  withMatrix size $ \list vec ->
+    [ ("Data.List.transpose/list", bench (renderSize size) $ nf List.transpose list)
+    , ("X.Data.Vector.Generic.transpose/vector", bench (renderSize size) $ nf Generic.transpose vec)
+    ] <>
+    -- Going to list and back takes forever, so we only include it in smaller benchmarks --
+    if size <= 2000 then
+      [("Data.List.transpose/vector", bench (renderSize size) $ nf vecListTranspose vec)]
+    else
+      []
+
+renderSize :: Int -> String
+renderSize n =
+  show n <> "²"
+
+vecListTranspose :: Boxed.Vector (Unboxed.Vector Int) -> Boxed.Vector (Unboxed.Vector Int)
+vecListTranspose =
+  Boxed.fromList .
+  fmap Unboxed.fromList .
+  List.transpose .
+  fmap Unboxed.toList .
+  Boxed.toList
+
+withMatrix :: Int -> ([[Int]] -> Boxed.Vector (Unboxed.Vector Int) -> a) -> a
+withMatrix size f =
+  let
+    list :: [[Int]]
+    list = List.replicate size [0..size]
+
+    vec :: Boxed.Vector (Unboxed.Vector Int)
+    vec = fmap Unboxed.fromList $ Boxed.fromList list
+  in
+    list `deepseq` vec `deepseq` f list vec

--- a/x-vector/src/X/Data/Vector.hs
+++ b/x-vector/src/X/Data/Vector.hs
@@ -12,6 +12,11 @@ module X.Data.Vector (
   -- ** Monadic mapping
   , mapMaybeM
   , imapMaybeM
+
+  -- * Modifying vectors
+
+  -- ** Transposition
+  , transpose
   ) where
 
 import           Data.Vector as Boxed
@@ -20,6 +25,11 @@ import           P hiding (mapMaybe)
 
 import qualified X.Data.Vector.Generic as Generic
 
+
+transpose :: Vector (Vector a) -> Vector (Vector a)
+transpose =
+  Generic.transpose
+{-# INLINE transpose #-}
 
 mapMaybe :: (a -> Maybe b) -> Vector a -> Vector b
 mapMaybe =

--- a/x-vector/src/X/Data/Vector/Generic.hs
+++ b/x-vector/src/X/Data/Vector/Generic.hs
@@ -1,8 +1,16 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 module X.Data.Vector.Generic (
     module Generic
+
+  -- * Accessors
+
+  -- ** Length information
+
+  , lengths
 
   -- * Elementwise operations
 
@@ -14,11 +22,18 @@ module X.Data.Vector.Generic (
   , mapMaybeM
   , imapMaybeM
 
+  -- * Modifying vectors
+
+  -- ** Transposition
+  , transpose
+
   -- * Fusion support
 
   -- ** Conversion to/from bundles
   , unstreamM
   ) where
+
+import           Control.Monad.ST (ST)
 
 import           Data.Vector.Fusion.Bundle (Step(..))
 import qualified Data.Vector.Fusion.Bundle as Bundle
@@ -29,9 +44,123 @@ import           Data.Vector.Fusion.Stream.Monadic (Stream(..))
 import qualified Data.Vector.Fusion.Stream.Monadic as Stream
 
 import           Data.Vector.Generic as Generic
+import qualified Data.Vector.Generic.Mutable as MGeneric
+import qualified Data.Vector.Unboxed as Unboxed
+import qualified Data.Vector.Unboxed.Mutable as MUnboxed
 
-import           P hiding (mapMaybe)
+import           P hiding (for, mapMaybe)
 
+
+-- | The 'transpose' function transposes the rows and columns of its argument.
+--
+--   For example:
+--
+--   > transpose [[1,2,3],[4,5,6]] == [[1,4],[2,5],[3,6]]
+--
+--   If some of the rows are shorter than the following rows, their elements are skipped:
+--
+--   > transpose [[10,11],[20],[],[30,31,32]] == [[10,20,30],[11,31],[32]]
+--
+transpose :: (Vector va a, Vector vv (va a)) => vv (va a) -> vv (va a)
+transpose xss =
+  if Generic.null xss then
+    Generic.empty
+  else
+    let
+      MinMax min_cols max_cols =
+        Unboxed.foldl' minmax (MinMax maxBound minBound) (lengths xss)
+    in
+      if min_cols == max_cols then
+        transposeMatrix xss max_cols
+      else
+        transposeJagged xss max_cols
+{-# INLINE transpose #-}
+
+transposeMatrix :: forall vv va a. (Vector va a, Vector vv (va a)) => vv (va a) -> Int -> vv (va a)
+transposeMatrix xss n_cols =
+  let
+    n_rows :: Int
+    !n_rows =
+      Generic.length xss
+  in
+    Generic.create $ do
+      yss <- MGeneric.unsafeNew n_cols
+      ys0 <- MGeneric.unsafeNew (n_cols * n_rows)
+
+      -- Walk rows in blocks of 16, so that they're kept in cache between loops
+      -- over columns - benchmarking suggests that blocks of 16 is a reasonably
+      -- optimal choice.
+      for' 16 0 n_rows $ \b ->
+        for 0 n_cols $ \i ->
+          for b (min (b + 16) n_rows) $ \j ->
+            let
+              !xs = xss `Generic.unsafeIndex` j
+              !x  = xs  `Generic.unsafeIndex` i
+            in
+              MGeneric.unsafeWrite ys0 (i * n_rows + j) x
+
+      for 0 n_cols $ \i -> do
+        !ys <-
+          Generic.unsafeFreeze $
+          MGeneric.unsafeSlice (i * n_rows) n_rows ys0
+
+        MGeneric.unsafeWrite yss i ys
+
+      pure yss
+{-# INLINE transposeMatrix #-}
+
+transposeJagged :: forall vv va a. (Vector va a, Vector vv (va a)) => vv (va a) -> Int -> vv (va a)
+transposeJagged xss max_cols =
+  let
+    n_rows :: Int
+    !n_rows =
+      Generic.length xss
+  in
+    Generic.create $ do
+      yss <- MGeneric.unsafeNew max_cols
+      ys0 <- MGeneric.unsafeNew (max_cols * n_rows)
+      ns <- MUnboxed.replicate max_cols 0
+
+      -- Walk rows in blocks of 16, so that they're kept in cache between loops
+      -- over columns - benchmarking suggests that blocks of 16 is a reasonably
+      -- optimal choice.
+      for' 16 0 n_rows $ \b ->
+        for 0 max_cols $ \i ->
+          for b (min (b + 16) n_rows) $ \j ->
+            let
+              !xs = xss `Generic.unsafeIndex` j
+            in
+              case i < Generic.length xs of
+                False ->
+                  pure ()
+                True -> do
+                  let
+                    !x = xs `Generic.unsafeIndex` i
+                  !n <- MGeneric.unsafeRead ns i
+                  MGeneric.unsafeWrite ys0 (i * n_rows + n) x
+                  MGeneric.unsafeWrite ns i (n + 1)
+
+      for 0 max_cols $ \i -> do
+        !n <-
+          MGeneric.unsafeRead ns i
+
+        !ys <-
+          Generic.unsafeFreeze $
+          MGeneric.unsafeSlice (i * n_rows) n ys0
+
+        MGeneric.unsafeWrite yss i ys
+
+      pure yss
+{-# INLINE transposeJagged #-}
+
+
+lengths :: (Vector va a, Vector vv (va a), Vector vn Int) => vv (va a) -> vn Int
+lengths =
+  unstream .
+  Bundle.map Generic.length .
+  Bundle.reVector .
+  stream
+{-# INLINE lengths #-}
 
 mapMaybe :: (Vector v a, Vector v b) => (a -> Maybe b) -> v a -> v b
 mapMaybe f =
@@ -106,3 +235,40 @@ unstreamM s = do
   xs <- MBundle.toList s
   return $ unstream $ Bundle.unsafeFromList (MBundle.size s) xs
 {-# INLINE_FUSED unstreamM #-}
+
+------------------------------------------------------------------------
+-- Utils
+
+for :: Int -> Int -> (Int -> ST s ()) -> ST s ()
+for !n0 !n f =
+  let
+    loop !i =
+      case i == n of
+        True ->
+          return ()
+        False ->
+          f i >> loop (i+1)
+  in
+    loop n0
+{-# INLINE for #-}
+
+for' :: Int -> Int -> Int -> (Int -> ST s ()) -> ST s ()
+for' !inc !n0 !n f =
+  let
+    loop !i =
+      case i >= n of
+        True ->
+          return ()
+        False ->
+          f i >> loop (i+inc)
+  in
+    loop n0
+{-# INLINE for' #-}
+
+data MinMax =
+  MinMax !Int !Int
+
+minmax :: MinMax -> Int -> MinMax
+minmax (MinMax min0 max0) n =
+  MinMax (min min0 n) (max max0 n)
+{-# INLINE minmax #-}

--- a/x-vector/src/X/Data/Vector/Primitive.hs
+++ b/x-vector/src/X/Data/Vector/Primitive.hs
@@ -12,14 +12,25 @@ module X.Data.Vector.Primitive (
   -- ** Monadic mapping
   , mapMaybeM
   , imapMaybeM
+
+  -- * Modifying vectors
+
+  -- ** Transposition
+  , transpose
   ) where
 
+import qualified Data.Vector as Boxed
 import           Data.Vector.Primitive as Primitive
 
 import           P hiding (mapMaybe)
 
 import qualified X.Data.Vector.Generic as Generic
 
+
+transpose :: Prim a => Boxed.Vector (Vector a) -> Boxed.Vector (Vector a)
+transpose =
+  Generic.transpose
+{-# INLINE transpose #-}
 
 mapMaybe :: (Prim a, Prim b) => (a -> Maybe b) -> Vector a -> Vector b
 mapMaybe =

--- a/x-vector/src/X/Data/Vector/Storable.hs
+++ b/x-vector/src/X/Data/Vector/Storable.hs
@@ -12,14 +12,25 @@ module X.Data.Vector.Storable (
   -- ** Monadic mapping
   , mapMaybeM
   , imapMaybeM
+
+  -- * Modifying vectors
+
+  -- ** Transposition
+  , transpose
   ) where
 
+import qualified Data.Vector as Boxed
 import           Data.Vector.Storable as Storable
 
 import           P hiding (mapMaybe)
 
 import qualified X.Data.Vector.Generic as Generic
 
+
+transpose :: Storable a => Boxed.Vector (Vector a) -> Boxed.Vector (Vector a)
+transpose =
+  Generic.transpose
+{-# INLINE transpose #-}
 
 mapMaybe :: (Storable a, Storable b) => (a -> Maybe b) -> Vector a -> Vector b
 mapMaybe =

--- a/x-vector/src/X/Data/Vector/Unboxed.hs
+++ b/x-vector/src/X/Data/Vector/Unboxed.hs
@@ -12,14 +12,25 @@ module X.Data.Vector.Unboxed (
   -- ** Monadic mapping
   , mapMaybeM
   , imapMaybeM
+
+  -- * Modifying vectors
+
+  -- ** Transposition
+  , transpose
   ) where
 
+import qualified Data.Vector as Boxed
 import           Data.Vector.Unboxed as Unboxed
 
 import           P hiding (mapMaybe)
 
 import qualified X.Data.Vector.Generic as Generic
 
+
+transpose :: Unbox a => Boxed.Vector (Vector a) -> Boxed.Vector (Vector a)
+transpose =
+  Generic.transpose
+{-# INLINE transpose #-}
 
 mapMaybe :: (Unbox a, Unbox b) => (a -> Maybe b) -> Vector a -> Vector b
 mapMaybe =

--- a/x-vector/test/Test/X/Data/Vector/Generic.hs
+++ b/x-vector/test/Test/X/Data/Vector/Generic.hs
@@ -10,13 +10,35 @@ import           P
 
 import           System.IO (IO)
 
-import           Test.QuickCheck (Property, (===), quickCheckAll)
+import           Test.QuickCheck (Property, (===), quickCheckAll, counterexample)
 import           Test.QuickCheck.Function (Fun, apply)
 import           Test.QuickCheck.Instances ()
 
 import qualified X.Data.Vector as Boxed
 import qualified X.Data.Vector.Generic as Generic
+import qualified X.Data.Vector.Unboxed as Unboxed
 
+
+prop_transpose :: [[Int]] -> Property
+prop_transpose xss =
+  let
+    yss =
+      List.transpose xss
+
+    zss =
+      Boxed.toList .
+      Boxed.map Unboxed.toList .
+      Generic.transpose .
+      Boxed.map Unboxed.fromList $
+      Boxed.fromList xss
+  in
+    counterexample "=== Original ===" .
+    counterexample (show xss) .
+    counterexample "=== Data.List ===" .
+    counterexample (show yss) .
+    counterexample "=== X.Data.Vector ===" .
+    counterexample (show zss) $
+      yss == zss
 
 prop_mapMaybe :: Fun Int (Maybe Int) -> [Int] -> Property
 prop_mapMaybe f =


### PR DESCRIPTION
This adds the `Data.List.transpose` function, but over vectors.

The main downside is that we pessimistically allocate the largest possible number of columns for each row and then trim it with `unsafeSlice` once we know how many columns that row will have. Not sure if there is a fast way we could determine the final layout up front, but this will only be sub-optimal in the case of jagged (non-rectangular) vectors.

/cc @amosr 