### PR TITLE
Fix invalid 'as' <-> 'asWith' comparison

### DIFF
--- a/x-aeson/test/Test/X/Data/Aeson.hs
+++ b/x-aeson/test/Test/X/Data/Aeson.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -15,6 +16,7 @@ import           System.IO (IO)
 import           Text.Show
 
 import           Disorder.Aeson
+import           Disorder.Core
 
 import           Test.QuickCheck
 import           Test.QuickCheck.Instances ()
@@ -59,8 +61,18 @@ prop_asText t =
 
 prop_as :: Text -> Property
 prop_as t =
-  asWith (parseJSON :: Value -> Parser Text) t === as t
+  discardError (asWith (parseJSON :: Value -> Parser Text) t)
+  ===
+  discardError (as t)
+
+discardError :: Either a b -> Either () b
+discardError = \case
+  Left _ ->
+    Left ()
+  Right x ->
+    Right x
 
 return []
 tests :: IO Bool
-tests = $quickCheckAll
+tests =
+  $disorderCheckEnvAll TestRunMore


### PR DESCRIPTION
Aeson post 0.8 changes the error messages reported in each of these paths, so we now discard them.

Couldn't use `first (const ())` here as I didn't want to add a dependency on `bifunctor`.

I increased the number of tests because it only fails 1 in 5 with tests set to 100.