### PR TITLE
Add asciiToLower

### DIFF
--- a/x-bytestring/ambiata-x-bytestring.cabal
+++ b/x-bytestring/ambiata-x-bytestring.cabal
@@ -25,6 +25,7 @@ library
 
 
   exposed-modules:
+                       X.Data.ByteString.Char8
                        X.Data.ByteString.Unsafe
 
 test-suite test
@@ -38,10 +39,12 @@ test-suite test
                        test
 
   build-depends:       base
+                     , QuickCheck                      == 2.8.*
                      , ambiata-disorder-core
                      , ambiata-disorder-jack
                      , ambiata-p
                      , ambiata-x-bytestring
                      , bytestring                      == 0.10.*
                      , quickcheck-instances            == 0.3.*
+                     , text                            >= 1.1        && < 1.3
                      , vector                          >= 0.10       && < 0.12

--- a/x-bytestring/src/X/Data/ByteString/Char8.hs
+++ b/x-bytestring/src/X/Data/ByteString/Char8.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+module X.Data.ByteString.Char8 (
+    asciiToLower
+  ) where
+
+import           Data.Bits ((.|.))
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+
+import           P
+
+-- | Convert ASCII uppercase letters to lowercase. Other bytes are not
+-- affected. This is much, much faster than 'Data.Text.toLower', but obviously
+-- doesn't work on UTF-8 beyond its ASCII subset.
+asciiToLower :: ByteString -> ByteString
+asciiToLower = {-# SCC asciiToLower #-} BS.map lower
+  where
+    lower w
+      | w >= 0x41 && w <= 0x5a = w .|. 0x20
+      | otherwise              = w
+{-# INLINABLE asciiToLower #-}

--- a/x-bytestring/test/Test/X/Data/ByteString/Char8.hs
+++ b/x-bytestring/test/Test/X/Data/ByteString/Char8.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+module Test.X.Data.ByteString.Char8 where
+
+import qualified Data.ByteString as BS
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+
+import           P
+
+import           System.IO (IO)
+
+import           Test.QuickCheck
+import           Test.QuickCheck.Instances ()
+
+import           X.Data.ByteString.Char8
+
+prop_asciiToLower_upper t =
+  let x = T.encodeUtf8 $ T.toLower t in
+  x === asciiToLower x
+
+prop_asciiToLower_idempotent x =
+  asciiToLower (asciiToLower x) === asciiToLower x
+
+prop_asciiToLower_text = forAll ascii $ \x ->
+  let x' = T.decodeUtf8 x
+      y = asciiToLower x
+      y' = T.encodeUtf8 $ T.toLower x' in
+  y' === y
+  where
+    ascii = fmap BS.pack . listOf $ choose (0, 127)
+
+return []
+tests :: IO Bool
+tests = $forAllProperties $ quickCheckWithResult (stdArgs { maxSuccess = 1000 })

--- a/x-bytestring/test/test.hs
+++ b/x-bytestring/test/test.hs
@@ -1,9 +1,11 @@
 import           Disorder.Core.Main
 
+import qualified Test.X.Data.ByteString.Char8
 import qualified Test.X.Data.ByteString.Unsafe
 
 main :: IO ()
 main =
   disorderMain [
-      Test.X.Data.ByteString.Unsafe.tests
+      Test.X.Data.ByteString.Char8.tests
+    , Test.X.Data.ByteString.Unsafe.tests
     ]


### PR DESCRIPTION
Using this in a couple of places now, so figured I should add it here. This is the fastest pure-Haskell implementation I know; it would probably be faster in C but I don't know how people feel about C in libraries like `x`.