### PR TITLE
Export Data.Attoparsec.ByteString from X.Data.Attoparsec.ByteString

### DIFF
--- a/x-attoparsec/ambiata-x-attoparsec.cabal
+++ b/x-attoparsec/ambiata-x-attoparsec.cabal
@@ -41,8 +41,7 @@ test-suite test
                        test
 
   build-depends:
-                       attoparsec
-                     , base
+                       base
                      , ambiata-disorder-core
                      , ambiata-p
                      , bytestring                      == 0.10.*

--- a/x-attoparsec/src/X/Data/Attoparsec/ByteString.hs
+++ b/x-attoparsec/src/X/Data/Attoparsec/ByteString.hs
@@ -4,11 +4,12 @@
 {-# LANGUAGE LambdaCase #-}
 
 module X.Data.Attoparsec.ByteString (
-    sepByByte1
+    module X
+  , sepByByte1
   ) where
 
-import           Data.Attoparsec.ByteString (Parser)
-import           Data.Attoparsec.ByteString (peekWord8, anyWord8)
+import           Data.Attoparsec.ByteString as X
+
 import           Data.Word (Word8)
 
 import           P

--- a/x-attoparsec/test/Test/X/Data/Attoparsec/ByteString.hs
+++ b/x-attoparsec/test/Test/X/Data/Attoparsec/ByteString.hs
@@ -4,7 +4,6 @@
 
 module Test.X.Data.Attoparsec.ByteString where
 
-import           Data.Attoparsec.ByteString (parseOnly, notWord8)
 import qualified Data.ByteString as BS
 import           Data.Word (Word8)
 

--- a/x-attoparsec/test/Test/X/Data/Attoparsec/Text.hs
+++ b/x-attoparsec/test/Test/X/Data/Attoparsec/Text.hs
@@ -9,7 +9,6 @@ import           System.IO ()
 import           Test.QuickCheck
 import           Test.QuickCheck.Instances ()
 
-import           Data.Attoparsec.Text
 import           X.Data.Attoparsec.Text
 
 prop_positiveIntegerParserSuccess :: Positive Integer -> Property


### PR DESCRIPTION
Just like [X.Data.Attoparsec.Text](https://github.com/ambiata/x/blob/master/x-attoparsec/src/X/Data/Attoparsec/Text.hs#L3) does it.

Then if a project needs only `Data.Attoparsec.ByteString` it will not need to explicitly depend on locked `attoparsec` but can depend on `x-attoparsec` only.

/cc @olorin