### PR TITLE
Add 'unsafeSplits' for generic vectors

### DIFF
--- a/x-vector/test/Test/X/Data/Vector/Generic.hs
+++ b/x-vector/test/Test/X/Data/Vector/Generic.hs
@@ -40,6 +40,20 @@ prop_transpose xss =
     counterexample (show zss) $
       yss == zss
 
+prop_splits :: [Boxed.Vector Int] -> Property
+prop_splits xss0_list =
+  let
+    xs =
+      Boxed.concat xss0_list
+
+    xss0 =
+      Boxed.fromList xss0_list
+
+    xss =
+      Generic.unsafeSplits id xs (fmap Boxed.length xss0)
+  in
+    xss0 === xss
+
 prop_mapMaybe :: Fun Int (Maybe Int) -> [Int] -> Property
 prop_mapMaybe f =
   equivalent


### PR DESCRIPTION
This is the same as [X.Data.ByteString.unsafeSplits](https://github.com/ambiata/x/blob/805c90051e042efc7c1ea91f8761e4cb88e896c6/x-bytestring/src/X/Data/ByteString/Unsafe.hs#L18-L29) but for vectors.

/cc @amosr @tranma 