### PR TITLE
x-vector: add growable vector, similar to a Java ArrayList

### DIFF
--- a/x-vector/ambiata-x-vector.cabal
+++ b/x-vector/ambiata-x-vector.cabal
@@ -14,6 +14,7 @@ library
   build-depends:
                        base                            >= 4.6        && < 5
                      , ambiata-p
+                     , primitive                       >= 0.6        && < 0.7
                      , vector                          >= 0.10       && < 0.12
 
   ghc-options:
@@ -26,9 +27,12 @@ library
   exposed-modules:
                        X.Data.Vector
                        X.Data.Vector.Generic
+                       X.Data.Vector.Grow
                        X.Data.Vector.Primitive
+                       X.Data.Vector.Ref
                        X.Data.Vector.Storable
                        X.Data.Vector.Unboxed
+
                        X.Data.Vector.Stream
                        X.Data.Vector.Stream.Conversion
                        X.Data.Vector.Stream.Enum

--- a/x-vector/src/X/Data/Vector/Grow.hs
+++ b/x-vector/src/X/Data/Vector/Grow.hs
@@ -1,0 +1,91 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+module X.Data.Vector.Grow (
+    Grow
+  , new
+  , length
+  , capacity
+  , add
+  , clear
+  , freeze
+  , unsafeFreeze
+  , unsafeElems
+  ) where
+
+import           X.Data.Vector.Ref (Ref, newRef, readRef, modifyRef, modifyRefM)
+
+import           Control.Monad.Primitive (PrimMonad, PrimState)
+
+import           Data.Vector.Generic (Vector, Mutable)
+import qualified Data.Vector.Generic as Generic
+import           Data.Vector.Generic.Mutable (MVector)
+import qualified Data.Vector.Generic.Mutable as MGeneric
+import qualified Data.Vector.Mutable as MBoxed
+
+import           P hiding (length)
+
+
+data GrowState v s a =
+  GrowState {
+      growLength :: !Int
+    , growVector :: !(v s a)
+    }
+
+newtype Grow v s a =
+  Grow {
+      unGrow :: Ref MBoxed.MVector s (GrowState v s a)
+    }
+
+new :: (PrimMonad m, MVector v a) => Int -> m (Grow v (PrimState m) a)
+new n = do
+  gs <- liftM (GrowState 0) $ MGeneric.new n
+  liftM Grow $ newRef gs
+{-# INLINE new #-}
+
+length :: PrimMonad m => Grow v (PrimState m) a -> m Int
+length =
+  liftM growLength . readRef . unGrow
+{-# INLINE length #-}
+
+capacity :: (PrimMonad m, MVector v a) => Grow v (PrimState m) a -> m Int
+capacity =
+  liftM (MGeneric.length . growVector) . readRef . unGrow
+{-# INLINE capacity #-}
+
+expand :: (PrimMonad m, MVector v a) => GrowState v (PrimState m) a -> m (GrowState v (PrimState m) a)
+expand gs@(GrowState n xs0) =
+  if n == MGeneric.length xs0 then
+    liftM (GrowState n) $
+      MGeneric.unsafeGrow xs0 (max n 1)
+  else
+    return gs
+{-# INLINE expand #-}
+
+add :: (PrimMonad m, MVector v a) => Grow v (PrimState m) a -> a -> m ()
+add (Grow ref) x =
+ modifyRefM ref $ \gs0 -> do
+   GrowState n xs <- expand gs0
+   MGeneric.unsafeWrite xs n x
+   return $ GrowState (n + 1) xs
+{-# INLINE add #-}
+
+clear :: PrimMonad m => Grow v (PrimState m) a -> m ()
+clear (Grow ref) =
+ modifyRef ref $ \(GrowState _ xs) ->
+   GrowState 0 xs
+{-# INLINE clear #-}
+
+freeze :: (PrimMonad m, Vector v a) => Grow (Mutable v) (PrimState m) a -> m (v a)
+freeze =
+  bind Generic.freeze . unsafeElems
+{-# INLINE freeze #-}
+
+unsafeFreeze :: (PrimMonad m, Vector v a) => Grow (Mutable v) (PrimState m) a -> m (v a)
+unsafeFreeze =
+  bind Generic.unsafeFreeze . unsafeElems
+{-# INLINE unsafeFreeze #-}
+
+unsafeElems :: (PrimMonad m, MVector v a) => Grow v (PrimState m) a -> m (v (PrimState m) a)
+unsafeElems (Grow ref) = do
+  GrowState n xs <- readRef ref
+  return $ MGeneric.unsafeTake n xs
+{-# INLINE unsafeElems #-}

--- a/x-vector/src/X/Data/Vector/Ref.hs
+++ b/x-vector/src/X/Data/Vector/Ref.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+module X.Data.Vector.Ref (
+    Ref
+  , newRef
+  , readRef
+  , writeRef
+  , modifyRef
+  , modifyRefM
+  ) where
+
+import           Control.Monad.Primitive (PrimMonad, PrimState)
+
+import           Data.Vector.Generic.Mutable (MVector)
+import qualified Data.Vector.Generic.Mutable as MGeneric
+
+import           P
+
+
+newtype Ref v s a =
+  Ref {
+      _unRef :: v s a
+    }
+
+newRef :: (PrimMonad m, MVector v a) => a -> m (Ref v (PrimState m) a)
+newRef =
+  liftM Ref . MGeneric.replicate 1
+{-# INLINE newRef #-}
+
+readRef :: (PrimMonad m, MVector v a) => Ref v (PrimState m) a -> m a
+readRef (Ref ref) =
+  MGeneric.unsafeRead ref 0
+{-# INLINE readRef #-}
+
+writeRef :: (PrimMonad m, MVector v a) => Ref v (PrimState m) a -> a -> m ()
+writeRef (Ref ref) =
+  MGeneric.unsafeWrite ref 0
+{-# INLINE writeRef #-}
+
+modifyRef :: (PrimMonad m, MVector v a) => Ref v (PrimState m) a -> (a -> a) -> m ()
+modifyRef (Ref ref) f = do
+  x <- MGeneric.unsafeRead ref 0
+  MGeneric.unsafeWrite ref 0 $ f x
+{-# INLINE modifyRef #-}
+
+modifyRefM :: (PrimMonad m, MVector v a) => Ref v (PrimState m) a -> (a -> m a) -> m ()
+modifyRefM (Ref ref) f = do
+  x0 <- MGeneric.unsafeRead ref 0
+  x <- f x0
+  MGeneric.unsafeWrite ref 0 x
+{-# INLINE modifyRefM #-}

--- a/x-vector/test/Test/X/Data/Vector/Grow.hs
+++ b/x-vector/test/Test/X/Data/Vector/Grow.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Test.X.Data.Vector.Grow where
+
+import           Control.Monad.ST (runST)
+
+import           P
+
+import           System.IO (IO)
+
+import           Test.QuickCheck (Property, (===), quickCheckAll)
+import           Test.QuickCheck.Instances ()
+
+import qualified X.Data.Vector.Grow as Grow
+import qualified X.Data.Vector.Unboxed as Unboxed
+
+
+prop_add_freeze :: [Int] -> Property
+prop_add_freeze xs0 =
+  let
+    xs =
+      Unboxed.fromList xs0
+  in
+    runST $ do
+      g <- Grow.new 0
+      Unboxed.mapM_ (Grow.add g) xs
+      ys <- Grow.freeze g
+      pure $
+        xs === ys
+
+return []
+tests :: IO Bool
+tests = $quickCheckAll

--- a/x-vector/test/Test/X/Data/Vector/Ref.hs
+++ b/x-vector/test/Test/X/Data/Vector/Ref.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Test.X.Data.Vector.Ref where
+
+import           Control.Monad.ST (runST)
+
+import qualified Data.Vector.Unboxed.Mutable as MUnboxed
+
+import           P
+
+import           System.IO (IO)
+
+import           Test.QuickCheck (Property, (===), quickCheckAll)
+import           Test.QuickCheck.Instances ()
+
+import           X.Data.Vector.Ref
+
+
+prop_read_after_new :: Int -> Property
+prop_read_after_new x =
+  runST $ do
+    (ref :: Ref MUnboxed.MVector s Int) <- newRef x
+    y <- readRef ref
+    pure $
+      x === y
+
+prop_read_after_write :: Int -> Property
+prop_read_after_write x =
+  runST $ do
+    (ref :: Ref MUnboxed.MVector s Int) <- newRef 0
+    writeRef ref x
+    y <- readRef ref
+    pure $
+      x === y
+
+return []
+tests :: IO Bool
+tests = $quickCheckAll


### PR DESCRIPTION
This adds two modules `X.Data.Vector.Ref` and `X.Data.Vector.Grow`.

`Ref` is similar to an `IORef`, but doesn't have the overhead of thread safety. It's parameterised by the vector used to store the value, so it can be boxed, unboxed or storable.

`Grow` is a mutable vector that can have elements pushed on to the back of it, then frozen in to an immutable vector - it is parameterised in a similar way to `Ref`.

/cc @amosr @tranma @markhibberd @nhibberd @olorin 