### PR TITLE
x-vector: support for efficient append to a grow vector

### DIFF
--- a/x-vector/test/Test/X/Data/Vector/Grow.hs
+++ b/x-vector/test/Test/X/Data/Vector/Grow.hs
@@ -29,6 +29,45 @@ prop_add_freeze xs0 =
       pure $
         xs === ys
 
+prop_append_freeze :: [Int] -> [Int] -> Property
+prop_append_freeze xs0 ys0 =
+  let
+    xs =
+      Unboxed.fromList xs0
+
+    ys =
+      Unboxed.fromList ys0
+  in
+    runST $ do
+      g <- Grow.new 0
+      Grow.append g xs
+      Grow.append g ys
+      zs <- Grow.freeze g
+      pure $
+        xs <> ys === zs
+
+prop_append_vs_add :: [Int] -> Property
+prop_append_vs_add xs0 =
+  let
+    xs =
+      Unboxed.fromList xs0
+
+    ys :: Unboxed.Vector Int
+    ys =
+      runST $ do
+        g <- Grow.new 0
+        Grow.append g xs
+        Grow.freeze g
+
+    zs :: Unboxed.Vector Int
+    zs =
+      runST $ do
+        g <- Grow.new 0
+        Unboxed.mapM_ (Grow.add g) xs
+        Grow.freeze g
+  in
+    ys === zs
+
 return []
 tests :: IO Bool
 tests = $quickCheckAll


### PR DESCRIPTION
The new `append` operation is equivalent to adding each of the elements of a vector one after another to the grow vector, as demonstrated by the property test.

/cc @tranma @amosr @olorin 