### PR TITLE
Add 'hoistMaybe', similar to 'hoistEither' but for Maybe

### DIFF
--- a/x-eithert/src/X/Control/Monad/Trans/Either.hs
+++ b/x-eithert/src/X/Control/Monad/Trans/Either.hs
@@ -19,6 +19,7 @@ module X.Control.Monad.Trans.Either (
   , firstEitherT
   , secondEitherT
   , eitherTFromMaybe
+  , hoistMaybe
   , hoistEitherT
   , mapEitherE
   , joinEitherT
@@ -129,6 +130,11 @@ eitherTFromMaybe :: Functor m => x -> m (Maybe a) -> EitherT x m a
 eitherTFromMaybe x =
   EitherT . fmap (maybe (Left x) Right)
 {-# INLINE eitherTFromMaybe #-}
+
+hoistMaybe :: Monad m => x -> Maybe a -> EitherT x m a
+hoistMaybe x =
+  maybe (left x) return
+{-# INLINE hoistMaybe #-}
 
 hoistEitherT :: (forall b. m b -> n b) -> EitherT x m a -> EitherT x n a
 hoistEitherT f =


### PR DESCRIPTION
```hs
hoistEither :: Monad m => Either x a -> EitherT x m a
```
vs
```hs
hoistMaybe :: Monad m => x -> Maybe a -> EitherT x m a
```

Not sure if this is worth it? I've used it in two places, so I thought it may be useful here.

An alternative is `hoistEither . maybeToRight x` or `eitherTFromMaybe x . pure`

/cc @tranma @nhibberd @charleso 