### PR TITLE
x-file-embed

### DIFF
--- a/boris.toml
+++ b/boris.toml
@@ -19,6 +19,9 @@
 [build.dist-7-10-x-exception]
   command = [["master", "build", "dist-7-10", "-C", "x-exception"]]
 
+[build.dist-7-10-x-file-embed]
+  command = [["master", "build", "dist-7-10", "-C", "x-file-embed"]]
+
 [build.dist-7-10-x-htoml]
   command = [["master", "build", "dist-7-10", "-C", "x-htoml"]]
 
@@ -52,6 +55,9 @@
 
 [build.branches-7-10-x-exception]
   command = [["master", "build", "branches-7-10", "-C", "x-exception"]]
+
+[build.branches-7-10-x-file-embed]
+  command = [["master", "build", "branches-7-10", "-C", "x-file-embed"]]
 
 [build.branches-7-10-x-htoml]
   command = [["master", "build", "branches-7-10", "-C", "x-htoml"]]

--- a/x-file-embed/.ghci
+++ b/x-file-embed/.ghci
@@ -1,0 +1,1 @@
+../framework/ghci

--- a/x-file-embed/ambiata-x-file-embed.cabal
+++ b/x-file-embed/ambiata-x-file-embed.cabal
@@ -1,0 +1,50 @@
+name:                  ambiata-x-file-embed
+version:               0.0.1
+license:               AllRightsReserved
+author:                Ambiata <info@ambiata.com>
+maintainer:            Ambiata <info@ambiata.com>
+copyright:             (c) 2015 Ambiata.
+synopsis:              x-file-embed
+category:              x-file-embed
+cabal-version:         >= 1.8
+build-type:            Simple
+description:           x-file-embed.
+
+library
+  build-depends:
+                       base                            >= 3          && < 5
+                     , ambiata-p
+                     , bytestring                      == 0.10.*
+                     , file-embed                      == 0.0.*
+                     , template-haskell                >= 2.8
+                     , text                            == 1.2.*
+
+  ghc-options:
+                       -Wall
+
+  hs-source-dirs:
+                       src
+
+
+  exposed-modules:
+                       X.Data.FileEmbed
+
+test-suite test
+  type:                exitcode-stdio-1.0
+
+  main-is:             test.hs
+
+  ghc-options:         -Wall -threaded -O2
+
+  hs-source-dirs:
+                       test
+
+  build-depends:
+                       base                            >= 3          && < 5
+                     , ambiata-p
+                     , ambiata-x-file-embed
+                     , ambiata-disorder-core
+                     , bytestring                      == 0.10.*
+                     , QuickCheck                      == 2.8.*
+                     , quickcheck-instances            == 0.3.*
+                     , text                            == 1.2.*

--- a/x-file-embed/mafia
+++ b/x-file-embed/mafia
@@ -1,0 +1,1 @@
+../framework/mafia

--- a/x-file-embed/master.toml
+++ b/x-file-embed/master.toml
@@ -1,0 +1,1 @@
+../framework/master.toml

--- a/x-file-embed/src/X/Data/FileEmbed.hs
+++ b/x-file-embed/src/X/Data/FileEmbed.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+module X.Data.FileEmbed (
+    embedWhen
+  , pairToExp
+  , module X
+  ) where
+
+import           Language.Haskell.TH.Syntax (Q, Exp(..), Lit(..), runIO, qAddDependentFile)
+
+import           Data.ByteString (ByteString)
+import           Data.FileEmbed as X
+
+import           P
+
+import           System.IO (FilePath)
+
+
+--- | Embed all the files in a directory that match a predicate, recursively.
+embedWhen :: (FilePath -> Bool) -> FilePath -> Q Exp
+embedWhen p dir = do
+  typ <- [t| [(FilePath, ByteString)] |]
+  files <- runIO (getDir dir)
+  efiles <- mapM (pairToExp dir) $ filter (p . fst) files
+  return $
+    SigE (ListE efiles) typ
+
+-- Not exposed from Data.FileEmbed
+pairToExp :: FilePath -> (FilePath, ByteString) -> Q Exp
+pairToExp root (path, bs) = do
+  qAddDependentFile $ root <> ('/' : path)
+  exp' <- bsToExp bs
+  return $!
+    TupE [LitE $ StringL path, exp']

--- a/x-file-embed/test/Test/X/Data/FileEmbed.hs
+++ b/x-file-embed/test/Test/X/Data/FileEmbed.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Test.X.Data.FileEmbed where
+
+import           Data.ByteString (ByteString)
+
+import           P
+
+import           System.IO (IO, FilePath)
+
+import           Test.QuickCheck (Property, (===), quickCheckAll, once)
+
+import           X.Data.FileEmbed (embedWhen)
+
+
+files :: [(FilePath, ByteString)]
+files =
+  $(embedWhen (== "foo.h") "test/example")
+
+prop_check :: Property
+prop_check =
+  once $
+    files === [("foo.h", "int foo (int x);\n")]
+
+return []
+tests :: IO Bool
+tests =
+  $quickCheckAll

--- a/x-file-embed/test/example/foo.c
+++ b/x-file-embed/test/example/foo.c
@@ -1,0 +1,4 @@
+int foo (int x)
+{
+    return x;
+}

--- a/x-file-embed/test/example/foo.h
+++ b/x-file-embed/test/example/foo.h
@@ -1,0 +1,1 @@
+int foo (int x);

--- a/x-file-embed/test/test.hs
+++ b/x-file-embed/test/test.hs
@@ -1,0 +1,9 @@
+import           Disorder.Core.Main
+
+import qualified Test.X.Data.FileEmbed
+
+main :: IO ()
+main =
+  disorderMain [
+      Test.X.Data.FileEmbed.tests
+    ]


### PR DESCRIPTION
`embedWhen` is a version of `embedDir` that takes a predicate to filter the files which you want to embed.

I want to put this here because if I put it in icicle then I get random linker errors in `hdevtools` which seem like they are staging problems.

Wasn't sure on the naming, we have `x-templatehaskell` instead of `x-template-haskell`, so maybe this should be `x-fileembed`? :shrugs:

! @amosr @nhibberd 