### PR TITLE
x-vector: Add 'grouped' combinator for chunking but maintaining groups

### DIFF
--- a/x-vector/src/X/Data/Vector/Stream/Group.hs
+++ b/x-vector/src/X/Data/Vector/Stream/Group.hs
@@ -5,7 +5,8 @@
 module X.Data.Vector.Stream.Group (
     embed
   , concatWith
-  , chunksOf
+  , chunked
+  , grouped
   ) where
 
 import           Control.Monad.Base (MonadBase(..))
@@ -32,39 +33,60 @@ concatWith =
   flip Stream.concatMap
 {-# INLINE [1] concatWith #-}
 
-chunksOf :: (PrimMonad b, MonadBase b m, Generic.Vector v a) => Int -> Stream m a -> Stream m (v a)
-chunksOf !n (Stream step t) =
+-- | Turns a stream of @a@ in to a stream of chunks of size @n@.
+chunked :: (PrimMonad b, MonadBase b m, Generic.Vector v a) => Int -> Stream m a -> Stream m (v a)
+chunked n xs =
   if n <= 0 then
-    Savage.error "X.Data.Vector.Stream.Group.chunksOf: chunk size must be greater than zero"
+    Savage.error "X.Data.Vector.Stream.Group.chunked: chunk size must be greater than zero"
+  else
+    grouped (\_ _ -> False) n xs
+{-# INLINE [1] chunked #-}
+
+-- | Turns a stream of @a@ in to a stream of chunks of at least size @n@,
+--   except for the last one. Values of @a@ which are equal according to the
+--   comparison function stay in the same chunk.
+grouped :: (PrimMonad b, MonadBase b m, Generic.Vector v a) => (a -> a -> Bool) -> Int -> Stream m a -> Stream m (v a)
+grouped eq n (Stream step t) =
+  if n <= 0 then
+    Savage.error "X.Data.Vector.Stream.Group.grouped: chunk size must be greater than zero"
   else
     embed $ do
       let
+        notEq mx y =
+          case mx of
+            Nothing' ->
+              True
+            Just' x ->
+              not (eq x y)
+        {-# INLINE [0] notEq #-}
+
         loop = \case
           Nothing' ->
             pure Done
 
-          Just' (s0, i, g0) ->
-            if i == n then do
-              xs <- liftBase $ Grow.unsafeFreeze g0
-              g <- liftBase $ Grow.new n
-              pure . Yield xs $ Just' (s0, 0, g)
-            else
-              step s0 >>= \case
-                Yield x s -> do
+          Just' (s0, i, last, g0) ->
+            step s0 >>= \case
+              Yield x s ->
+                if i >= n && last `notEq` x then do
+                  xs <- liftBase $ Grow.unsafeFreeze g0
+                  g <- liftBase $ Grow.new n
+                  liftBase $ Grow.add g x
+                  pure . Yield xs $ Just' (s, 1, Just' x, g)
+                else do
                   liftBase $ Grow.add g0 x
-                  pure . Skip $ Just' (s, i + 1, g0)
-                Skip s ->
-                  pure . Skip $ Just' (s, i, g0)
-                Done ->
-                  if i == 0 then
-                    pure $ Skip Nothing'
-                  else do
-                    xs <- liftBase $ Grow.unsafeFreeze g0
-                    pure $ Yield xs Nothing'
+                  pure . Skip $ Just' (s, i + 1, Just' x, g0)
+              Skip s ->
+                pure . Skip $ Just' (s, i, last, g0)
+              Done ->
+                if i == 0 then
+                  pure $ Skip Nothing'
+                else do
+                  xs <- liftBase $ Grow.unsafeFreeze g0
+                  pure $ Yield xs Nothing'
         {-# INLINE [0] loop #-}
 
       g <- liftBase $ Grow.new n
 
       pure .
-        Stream loop $ Just' (t, 0, g)
-{-# INLINE [1] chunksOf #-}
+        Stream loop $ Just' (t, 0, Nothing', g)
+{-# INLINE [1] grouped #-}

--- a/x-vector/test/Test/X/Data/Vector/Stream/Group.hs
+++ b/x-vector/test/Test/X/Data/Vector/Stream/Group.hs
@@ -5,6 +5,8 @@ module Test.X.Data.Vector.Stream.Group where
 
 import           Control.Monad.ST (runST)
 
+import qualified Data.List as List
+
 import           P
 
 import           System.IO (IO)
@@ -17,13 +19,13 @@ import qualified X.Data.Vector.Stream as Stream
 import qualified X.Data.Vector.Unboxed as Unboxed
 
 
-prop_chunksOf :: Int -> [Int] -> Property
-prop_chunksOf n xs0 =
+prop_chunked :: Int -> [Int] -> Property
+prop_chunked n xs0 =
   n > 0 ==>
   runST $ do
     let
       yss0 =
-        Stream.chunksOf n $
+        Stream.chunked n $
         Stream.fromList xs0
 
     yss <- Stream.toList yss0
@@ -42,6 +44,19 @@ prop_chunksOf n xs0 =
       subprop_same_values <>
       subprop_at_most_n <>
       subprop_no_empty
+
+prop_grouped_vs_oracle :: [Int] -> Property
+prop_grouped_vs_oracle xs0 =
+  runST $ do
+    let
+      yss0 =
+        Stream.grouped (==) 1 $
+        Stream.fromList xs0
+
+    yss <- Stream.toList yss0
+
+    pure $
+      List.group xs0 === fmap Unboxed.toList yss
 
 return []
 tests :: IO Bool


### PR DESCRIPTION
I'm currently using `chunked` in blizzard to create zebra blocks, but I should actually use `grouped` so that entities do not span across blocks.

! @amosr @tranma 