### PR TITLE
Widen bounds for optparse-applicative to include 0.13

### DIFF
--- a/x-optparse/ambiata-x-optparse.cabal
+++ b/x-optparse/ambiata-x-optparse.cabal
@@ -13,8 +13,9 @@ description:           x-optparse.
 library
   build-depends:
                        base                            >= 3          && < 5
+                     , ambiata-p
                      , attoparsec                      >= 0.12       && < 0.14
-                     , optparse-applicative            >= 0.11       && < 0.13
+                     , optparse-applicative            >= 0.11       && < 0.14
                      , text                            == 1.2.*
                      , transformers                    >= 0.4        && < 0.6
 

--- a/x-optparse/ambiata-x-optparse.lock-7.10.2
+++ b/x-optparse/ambiata-x-optparse.lock-7.10.2
@@ -2,12 +2,17 @@
 ansi-terminal == 0.6.2.3
 ansi-wl-pprint == 0.6.7.3
 attoparsec == 0.13.1.0
+base-orphans == 0.5.4
+bifunctors == 5.3
+comonad == 5
+contravariant == 1.4
+distributive == 0.5.0.2
 fail == 4.9.0.0
 hashable == 1.2.4.0
-ieee754 == 0.7.8
+ieee754 == 0.7.9
 old-locale == 1.0.0.7
 old-time == 1.1.0.3
-optparse-applicative == 0.12.1.0
+optparse-applicative == 0.13.0.0
 primitive == 0.6.1.0
 QuickCheck == 2.8.2
 quickcheck-instances == 0.3.12
@@ -16,9 +21,12 @@ random == 1.1
 scientific == 0.3.4.9
 semigroups == 0.18.2
 semigroups -bytestring-builder
+StateVar == 1.1.0.4
+stm == 2.4.4.1
 tagged == 0.8.5
 text == 1.2.2.1
 tf-random == 0.5
 transformers-compat == 0.5.1.4
 unordered-containers == 0.2.7.1
 vector == 0.11.0.0
+void == 0.7.1

--- a/x-optparse/src/X/Options/Applicative.hs
+++ b/x-optparse/src/X/Options/Applicative.hs
@@ -17,28 +17,18 @@ module X.Options.Applicative (
   , dryRunFlag
   ) where
 
-import           Control.Monad ((>>=), (>>), mapM)
-
 import qualified Data.Attoparsec.Text as A
-import           Data.Char (Char)
-import           Data.Eq (Eq)
-import           Data.Either (Either (..), either)
-import           Data.Function (($), (.))
-import           Data.Functor (fmap)
-import           Data.Monoid (mempty)
-import           Data.Maybe (Maybe, maybe)
 import           Data.String (String)
-import           Data.Text (Text)
 import qualified Data.Text as T
 
 import           Options.Applicative as X
 import           Options.Applicative.Types as X
 
+import           P
+
 import           System.IO (IO, putStrLn, print)
 import           System.Environment (getArgs)
 import           System.Exit (exitSuccess)
-
-import           Text.Show (Show)
 
 
 data RunType =


### PR DESCRIPTION
This allows the use of [commandGroup](http://hackage.haskell.org/package/optparse-applicative-0.13.0.0/docs/Options-Applicative-Builder.html#v:commandGroup) for grouping commands. 

! @nhibberd @charleso 