### PR TITLE
x-eithert support for GHC 7.8

### DIFF
--- a/boris.toml
+++ b/boris.toml
@@ -1,6 +1,13 @@
 [boris]
   version = 1
 
+
+[build.dist-7-8-x-eithert]
+  command = [["master", "build", "dist-7-8", "-C", "x-eithert"]]
+
+[build.dist-7-8-x-optparse]
+  command = [["master", "build", "dist-7-8", "-C", "x-optparse"]]
+
 [build.dist-7-10-x-aeson]
   command = [["master", "build", "dist-7-10", "-C", "x-aeson"]]
 
@@ -37,6 +44,15 @@
 [build.dist-7-10-x-vector]
   command = [["master", "build", "dist-7-10", "-C", "x-vector"]]
 
+[build.dist-validate]
+  command = [["validate-respect"]]
+
+
+[build.branches-7-8-x-eithert]
+  command = [["master", "build", "branches-7-8", "-C", "x-eithert"]]
+
+[build.branches-7-8-x-optparse]
+  command = [["master", "build", "branches-7-8", "-C", "x-optparse"]]
 
 [build.branches-7-10-x-aeson]
   command = [["master", "build", "branches-7-10", "-C", "x-aeson"]]
@@ -74,8 +90,6 @@
 [build.branches-7-10-x-vector]
   command = [["master", "build", "branches-7-10", "-C", "x-vector"]]
 
-[build.dist-validate]
-  command = [["validate-respect"]]
 
 [build.all-submodules]
   command = [["dangling-refs"]]

--- a/framework/master.toml
+++ b/framework/master.toml
@@ -1,13 +1,21 @@
 [master]
-  runner = "s3://ambiata-dispensary-v2/dist/master/master-haskell/linux/x86_64/20160614225955-a2cc8b9/master-haskell-20160614225955-a2cc8b9"
+  runner = "s3://ambiata-dispensary-v2/dist/master/master-haskell/linux/x86_64/20170104233312-ee8addd/master-haskell-20170104233312-ee8addd"
   version = 1
-  sha1 = "f827e1ff43bcaa325d128662391d95a8b4d65525"
+  sha1 = "3b707a2ba2d74ee13fe81a658bed191a5808e6f5"
+
+[build.dist-7-8]
+  GHC_VERSION="7.8.4"
+  CABAL_VERSION="1.22.4.0"
 
 [build.dist-7-10]
   GHC_VERSION="7.10.2"
   CABAL_VERSION="1.22.4.0"
   HADDOCK = "true"
   HADDOCK_S3 = "$AMBIATA_HADDOCK_MASTER"
+
+[build.branches-7-8]
+  GHC_VERSION="7.8.4"
+  CABAL_VERSION="1.22.4.0"
 
 [build.branches-7-10]
   GHC_VERSION = "7.10.2"

--- a/x-eithert/src/X/Control/Monad/Trans/Either.hs
+++ b/x-eithert/src/X/Control/Monad/Trans/Either.hs
@@ -233,6 +233,6 @@ sequenceEither =
 -- Note that this means each action will be run independently, regardless of failure.
 sequenceEitherT :: (Monad m, Monoid x, Traversable t) => t (EitherT x m a) -> EitherT x m (t a)
 sequenceEitherT es = do
-  es' <- lift (traverse runEitherT es)
+  es' <- lift (mapM runEitherT es)
   hoistEither (sequenceEither es')
 {-# INLINE sequenceEitherT #-}


### PR DESCRIPTION
I want mafia to support the last 3 major ghc releases, so this adds builds for `x-eithert` and `x-optparse` to make sure we don't break compatibility.

I also upgraded the master runner to the new one which uses `mafia` on the `PATH` on the build bot, rather than the shell script.

! @erikd-ambiata @thumphries 