### PR TITLE
Add syntax shorthand to x-templatehaskell

### DIFF
--- a/boris.toml
+++ b/boris.toml
@@ -8,6 +8,9 @@
 [build.dist-7-8-x-optparse]
   command = [["master", "build", "dist-7-8", "-C", "x-optparse"]]
 
+[build.dist-7-8-x-templatehaskell]
+  command = [["master", "build", "dist-7-8", "-C", "x-templatehaskell"]]
+
 [build.dist-7-10-x-aeson]
   command = [["master", "build", "dist-7-10", "-C", "x-aeson"]]
 

--- a/x-templatehaskell/ambiata-x-templatehaskell.cabal
+++ b/x-templatehaskell/ambiata-x-templatehaskell.cabal
@@ -26,6 +26,7 @@ library
 
   exposed-modules:
                        X.Language.Haskell.TH
+                       X.Language.Haskell.TH.Syntax
 
 test-suite test
   type:                exitcode-stdio-1.0

--- a/x-templatehaskell/src/X/Language/Haskell/TH/Syntax.hs
+++ b/x-templatehaskell/src/X/Language/Haskell/TH/Syntax.hs
@@ -1,0 +1,213 @@
+{-| Some shorthand for constructing Haskell98-ish TH syntax trees.
+    This is a defense mechanism against upstream template-haskell churn.
+    The idea is to provide a stable bare-minimum interface protected by CPP,
+    and use lenses to set/get the unstable fields. -}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections #-}
+module X.Language.Haskell.TH.Syntax (
+  -- * Declarations
+    data_
+  , val_
+  , fun_
+  , sig
+  -- ** Constructors
+  , normalC
+  , normalC_
+  , normalC_'
+  -- * Types
+  , conT
+  , appT
+  , arrowT
+  , arrowT_
+  , listT
+  , listT_
+  -- * Expressions
+  , litE
+  , varE
+  , conE
+  , lamE
+  , appE
+  , applyE
+  , caseE
+  , listE
+  -- * Patterns
+  , varP
+  , conP
+  -- * Matches
+  , match
+  , match_
+  -- * Literals
+  , stringL
+  , stringL_
+  -- * Names
+  , TH.mkName
+  , mkName_
+  ) where
+
+
+import           Data.Char (Char)
+import           Data.Foldable (foldl')
+import           Data.Function ((.))
+import           Data.Functor (Functor(..))
+import           Data.Text (Text)
+import qualified Data.Text as T
+
+import           Language.Haskell.TH (Dec (..), Con (..), Type (..), Name, Exp (..), Match (..), Pat (..), Lit (..))
+import qualified Language.Haskell.TH as TH
+import qualified Language.Haskell.TH.Syntax as S
+
+
+-- Everything below is as of template-haskell-2.10
+-- Upgraders will need to CPP everything in this module.
+
+
+-- -----------------------------------------------------------------------------
+-- Declarations
+
+-- | Declare a simple datatype.
+data_ ::
+     Name -- ^ The declared type's name
+  -> [Name] -- ^ Optional list of type parameters
+  -> [Con] -- ^ Constructors
+  -> Dec
+data_ n ps cs =
+  DataD [] n (fmap TH.PlainTV ps) cs []
+
+-- | Declare a simple function.
+fun_ :: Name -> [Pat] -> Exp -> Dec
+fun_ n ps e =
+  FunD n [TH.Clause ps (TH.NormalB e) []]
+
+-- | Declare a simple value.
+val_ :: Pat -> Exp -> Dec
+val_ p e =
+  ValD p (TH.NormalB e) []
+
+-- | A simple type signature declaration.
+sig :: Name -> Type -> Dec
+sig =
+  SigD
+
+-- -----------------------------------------------------------------------------
+-- Constructors
+
+-- | A regular constructor, with strict or nonstrict arguments.
+normalC :: Name -> [(S.Strict, Type)] -> Con
+normalC =
+  NormalC
+
+-- | A regular constructor, with nonstrict arguments.
+normalC_ :: Name -> [Type] -> Con
+normalC_ n =
+  normalC n . fmap (S.NotStrict,)
+
+-- | A regular constructor, with strict arguments.
+normalC_' :: Name -> [Type] -> Con
+normalC_' n =
+  normalC n . fmap (S.IsStrict,)
+
+-- -----------------------------------------------------------------------------
+-- Types
+
+conT :: Name -> Type
+conT =
+  ConT
+
+appT :: Type -> Type -> Type
+appT =
+  AppT
+
+arrowT :: Type
+arrowT =
+  ArrowT
+
+arrowT_ :: Type -> Type -> Type
+arrowT_ t =
+  appT (appT arrowT t)
+
+listT :: Type
+listT =
+  ListT
+
+listT_ :: Type -> Type
+listT_ =
+  appT listT
+
+-- -----------------------------------------------------------------------------
+-- Expressions
+
+litE :: Lit -> Exp
+litE =
+  LitE
+
+varE :: Name -> Exp
+varE =
+  VarE
+
+conE :: Name -> Exp
+conE =
+  ConE
+
+lamE :: [Pat] -> Exp -> Exp
+lamE =
+  LamE
+
+appE :: Exp -> Exp -> Exp
+appE =
+  AppE
+
+-- | Left-biased function application.
+applyE :: Exp -> [Exp] -> Exp
+applyE =
+  foldl' appE
+
+caseE :: Exp -> [Match] -> Exp
+caseE =
+  CaseE
+
+listE :: [Exp] -> Exp
+listE =
+  ListE
+
+-- -----------------------------------------------------------------------------
+-- Patterns
+
+varP :: Name -> Pat
+varP =
+  VarP
+
+conP :: Name -> [Pat] -> Pat
+conP =
+  ConP
+
+-- -----------------------------------------------------------------------------
+-- Matches
+
+-- | Construct a pattern match with no where clause.
+match :: Pat -> TH.Body -> Match
+match p b =
+  Match p b []
+
+-- | Construct an unguarded pattern match with no where clause.
+match_ :: Pat -> Exp -> Match
+match_ p e =
+  match p (TH.NormalB e)
+
+-- -----------------------------------------------------------------------------
+-- Literals
+
+stringL :: [Char] -> Lit
+stringL =
+  StringL
+
+stringL_ :: Text -> Lit
+stringL_ =
+  stringL . T.unpack
+
+-- -----------------------------------------------------------------------------
+-- Names
+
+mkName_ :: Text -> TH.Name
+mkName_ =
+  TH.mkName . T.unpack

--- a/x-templatehaskell/src/X/Language/Haskell/TH/Syntax.hs
+++ b/x-templatehaskell/src/X/Language/Haskell/TH/Syntax.hs
@@ -16,6 +16,9 @@ module X.Language.Haskell.TH.Syntax (
   , normalC
   , normalC_
   , normalC_'
+  -- *** Strictness annotations
+  , isStrict
+  , notStrict
   -- * Types
   , conT
   , appT

--- a/x-templatehaskell/src/X/Language/Haskell/TH/Syntax.hs
+++ b/x-templatehaskell/src/X/Language/Haskell/TH/Syntax.hs
@@ -65,10 +65,6 @@ import qualified Language.Haskell.TH as TH
 import qualified Language.Haskell.TH.Syntax as S
 
 
--- Everything below is as of template-haskell-2.10
--- Upgraders will need to CPP everything in this module.
-
-
 -- -----------------------------------------------------------------------------
 -- Declarations
 


### PR DESCRIPTION
Adds some shorthand for constructing Haskell98-ish TH syntax trees.

This is intended as a defense mechanism against upstream `template-haskell` churn. The idea is to provide a stable bare-minimum interface protected by CPP, and provide lenses to set/get the unstable fields.

Will provide some simple lenses (like where-clauses) in `X.Language.Haskell.TH.Lens` at some point. Since we don't need prisms or isos we can do this without dependencies.

! @jystic @charleso @amosr 