### PR TITLE
Fast equality for constant strings

### DIFF
--- a/x-bytestring/ambiata-x-bytestring.cabal
+++ b/x-bytestring/ambiata-x-bytestring.cabal
@@ -18,13 +18,14 @@ library
                      , vector                          >= 0.10       && < 0.12
 
   ghc-options:
-                       -Wall
+                       -Wall -O2
 
   hs-source-dirs:
                        src
 
 
   exposed-modules:
+                       X.Data.ByteString
                        X.Data.ByteString.Char8
                        X.Data.ByteString.Unsafe
 

--- a/x-bytestring/src/X/Data/ByteString.hs
+++ b/x-bytestring/src/X/Data/ByteString.hs
@@ -1,0 +1,116 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module X.Data.ByteString (
+    eq1
+  , eq2
+  , eq3
+  , eq4
+  , eq5
+
+  , module Data.ByteString
+  ) where
+
+import           Data.Bits
+import           Data.ByteString
+import           Data.ByteString.Internal (ByteString(..), accursedUnutterablePerformIO)
+import           Data.Word (Word8, Word16, Word32)
+
+import           Foreign.ForeignPtr (withForeignPtr)
+import           Foreign.Storable (peekByteOff)
+
+import           P
+
+
+-- | Fast equality for a 1-byte string.
+eq1 :: Word8 -> ByteString -> Bool
+eq1 x0 (PS fp off len) =
+  let
+    ok =
+      accursedUnutterablePerformIO $! withForeignPtr fp $! \ptr -> do
+        !y0 <- peekByteOff ptr off
+        pure $!
+          x0 == y0
+  in
+    len == 1 && ok
+{-# INLINE eq1 #-}
+
+-- | Fast equality for a 2-byte string.
+eq2 :: Word8 -> Word8 -> ByteString -> Bool
+eq2 x0 x1 (PS fp off len) =
+  let
+    x01 :: Word16
+    !x01 =
+      (fromIntegral x0) .|.
+      (fromIntegral x1 `shiftL` 8)
+
+    ok =
+      accursedUnutterablePerformIO $! withForeignPtr fp $! \ptr -> do
+        !y01 <- peekByteOff ptr off
+        pure $!
+          x01 == y01
+  in
+    len == 2 && ok
+{-# INLINE eq2 #-}
+
+-- | Fast equality for a 3-byte string.
+eq3 :: Word8 -> Word8 -> Word8 -> ByteString -> Bool
+eq3 x0 x1 x2 (PS fp off len) =
+  let
+    x01 :: Word16
+    !x01 =
+      (fromIntegral x0) .|.
+      (fromIntegral x1 `shiftL` 8)
+
+    ok =
+      accursedUnutterablePerformIO $! withForeignPtr fp $! \ptr -> do
+        !y01 <- peekByteOff ptr off
+        !y2 <- peekByteOff ptr (off + 2)
+        pure $!
+          x01 == y01 &&
+          x2 == y2
+  in
+    len == 3 && ok
+{-# INLINE eq3 #-}
+
+-- | Fast equality for a 4-byte string.
+eq4 :: Word8 -> Word8 -> Word8 -> Word8 -> ByteString -> Bool
+eq4 x0 x1 x2 x3 (PS fp off len) =
+  let
+    x0123 :: Word32
+    !x0123 =
+      (fromIntegral x0) .|.
+      (fromIntegral x1 `shiftL` 8) .|.
+      (fromIntegral x2 `shiftL` 16) .|.
+      (fromIntegral x3 `shiftL` 16)
+
+    ok =
+      accursedUnutterablePerformIO $! withForeignPtr fp $! \ptr -> do
+        !y0123 <- peekByteOff ptr off
+        pure $!
+          x0123 == y0123
+  in
+    len == 4 && ok
+{-# INLINE eq4 #-}
+
+-- | Fast equality for a 5-byte string.
+eq5 :: Word8 -> Word8 -> Word8 -> Word8 -> Word8 -> ByteString -> Bool
+eq5 x0 x1 x2 x3 x4 (PS fp off len) =
+  let
+    x0123 :: Word32
+    !x0123 =
+      (fromIntegral x0) .|.
+      (fromIntegral x1 `shiftL` 8) .|.
+      (fromIntegral x2 `shiftL` 16) .|.
+      (fromIntegral x3 `shiftL` 16)
+
+    ok =
+      accursedUnutterablePerformIO $! withForeignPtr fp $! \ptr -> do
+        !y0123 <- peekByteOff ptr off
+        !y4 <- peekByteOff ptr (off + 4)
+        pure $!
+          x0123 == y0123 &&
+          x4 == y4
+  in
+    len == 5 && ok
+{-# INLINE eq5 #-}

--- a/x-bytestring/src/X/Data/ByteString/Char8.hs
+++ b/x-bytestring/src/X/Data/ByteString/Char8.hs
@@ -1,21 +1,77 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 module X.Data.ByteString.Char8 (
     asciiToLower
+
+  , eq1
+  , eq2
+  , eq3
+  , eq4
+  , eq5
+
+  , module Data.ByteString.Char8
   ) where
 
 import           Data.Bits ((.|.))
-import           Data.ByteString (ByteString)
-import qualified Data.ByteString as BS
+import           Data.ByteString.Char8
+import           Data.Char (ord)
 
 import           P
+
+import qualified X.Data.ByteString as B
+
 
 -- | Convert ASCII uppercase letters to lowercase. Other bytes are not
 -- affected. This is much, much faster than 'Data.Text.toLower', but obviously
 -- doesn't work on UTF-8 beyond its ASCII subset.
 asciiToLower :: ByteString -> ByteString
-asciiToLower = {-# SCC asciiToLower #-} BS.map lower
+asciiToLower = {-# SCC asciiToLower #-} B.map lower
   where
     lower w
       | w >= 0x41 && w <= 0x5a = w .|. 0x20
       | otherwise              = w
 {-# INLINABLE asciiToLower #-}
+
+-- | Fast equality for a 1-byte string.
+eq1 :: Char -> ByteString -> Bool
+eq1 x0 =
+  B.eq1
+    (fromIntegral $ ord x0)
+{-# INLINE eq1 #-}
+
+-- | Fast equality for a 2-byte string.
+eq2 :: Char -> Char -> ByteString -> Bool
+eq2 x0 x1 =
+  B.eq2
+    (fromIntegral $ ord x0)
+    (fromIntegral $ ord x1)
+{-# INLINE eq2 #-}
+
+-- | Fast equality for a 3-byte string.
+eq3 :: Char -> Char -> Char -> ByteString -> Bool
+eq3 x0 x1 x2 =
+  B.eq3
+    (fromIntegral $ ord x0)
+    (fromIntegral $ ord x1)
+    (fromIntegral $ ord x2)
+{-# INLINE eq3 #-}
+
+-- | Fast equality for a 4-byte string.
+eq4 :: Char -> Char -> Char -> Char -> ByteString -> Bool
+eq4 x0 x1 x2 x3 =
+  B.eq4
+    (fromIntegral $ ord x0)
+    (fromIntegral $ ord x1)
+    (fromIntegral $ ord x2)
+    (fromIntegral $ ord x3)
+{-# INLINE eq4 #-}
+
+-- | Fast equality for a 5-byte string.
+eq5 :: Char -> Char -> Char -> Char -> Char -> ByteString -> Bool
+eq5 x0 x1 x2 x3 x4 =
+  B.eq5
+    (fromIntegral $ ord x0)
+    (fromIntegral $ ord x1)
+    (fromIntegral $ ord x2)
+    (fromIntegral $ ord x3)
+    (fromIntegral $ ord x4)
+{-# INLINE eq5 #-}

--- a/x-bytestring/src/X/Data/ByteString/Unsafe.hs
+++ b/x-bytestring/src/X/Data/ByteString/Unsafe.hs
@@ -4,9 +4,12 @@
 module X.Data.ByteString.Unsafe (
     unsafeSplits
   , unsafeSlice
+
+  , module Data.ByteString.Unsafe
   ) where
 
 import           Data.ByteString.Internal (ByteString(..))
+import           Data.ByteString.Unsafe
 import qualified Data.Vector.Generic as Generic
 
 import           P

--- a/x-bytestring/test/Test/X/Data/ByteString.hs
+++ b/x-bytestring/test/Test/X/Data/ByteString.hs
@@ -1,0 +1,72 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Test.X.Data.ByteString where
+
+import           Disorder.Jack (Property, quickCheckAll)
+import           Disorder.Jack ((===), gamble, arbitrary)
+
+import           P
+
+import           System.IO (IO)
+
+import           Test.QuickCheck.Instances ()
+
+import qualified X.Data.ByteString as B
+
+
+prop_eq1 :: Property
+prop_eq1 =
+  gamble arbitrary $ \x0 ->
+  gamble arbitrary $ \xs ->
+    (B.eq1 x0 xs)
+    ===
+    (B.pack [x0] == xs)
+
+prop_eq2 :: Property
+prop_eq2 =
+  gamble arbitrary $ \x0 ->
+  gamble arbitrary $ \x1 ->
+  gamble arbitrary $ \xs ->
+    (B.eq2 x0 x1 xs)
+    ===
+    (B.pack [x0, x1] == xs)
+
+prop_eq3 :: Property
+prop_eq3 =
+  gamble arbitrary $ \x0 ->
+  gamble arbitrary $ \x1 ->
+  gamble arbitrary $ \x2 ->
+  gamble arbitrary $ \xs ->
+    (B.eq3 x0 x1 x2 xs)
+    ===
+    (B.pack [x0, x1, x2] == xs)
+
+prop_eq4 :: Property
+prop_eq4 =
+  gamble arbitrary $ \x0 ->
+  gamble arbitrary $ \x1 ->
+  gamble arbitrary $ \x2 ->
+  gamble arbitrary $ \x3 ->
+  gamble arbitrary $ \xs ->
+    (B.eq4 x0 x1 x2 x3 xs)
+    ===
+    (B.pack [x0, x1, x2, x3] == xs)
+
+prop_eq5 :: Property
+prop_eq5 =
+  gamble arbitrary $ \x0 ->
+  gamble arbitrary $ \x1 ->
+  gamble arbitrary $ \x2 ->
+  gamble arbitrary $ \x3 ->
+  gamble arbitrary $ \x4 ->
+  gamble arbitrary $ \xs ->
+    (B.eq5 x0 x1 x2 x3 x4 xs)
+    ===
+    (B.pack [x0, x1, x2, x3, x4] == xs)
+
+return []
+tests :: IO Bool
+tests =
+  $quickCheckAll

--- a/x-bytestring/test/Test/X/Data/ByteString/Char8.hs
+++ b/x-bytestring/test/Test/X/Data/ByteString/Char8.hs
@@ -4,33 +4,92 @@
 {-# OPTIONS_GHC -fno-warn-missing-signatures #-}
 module Test.X.Data.ByteString.Char8 where
 
-import qualified Data.ByteString as BS
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
+
+import           Disorder.Jack (Args(..), stdArgs, forAllProperties, quickCheckWithResult)
+import           Disorder.Jack (Property, (===), gamble, arbitrary, listOf, choose)
 
 import           P
 
 import           System.IO (IO)
 
-import           Test.QuickCheck
 import           Test.QuickCheck.Instances ()
 
-import           X.Data.ByteString.Char8
+import qualified X.Data.ByteString as B
+import qualified X.Data.ByteString.Char8 as Char8
 
-prop_asciiToLower_upper t =
-  let x = T.encodeUtf8 $ T.toLower t in
-  x === asciiToLower x
 
-prop_asciiToLower_idempotent x =
-  asciiToLower (asciiToLower x) === asciiToLower x
+prop_asciiToLower_upper :: Property
+prop_asciiToLower_upper =
+  gamble arbitrary $ \t ->
+    let x = T.encodeUtf8 $ T.toLower t in
+    x === Char8.asciiToLower x
 
-prop_asciiToLower_text = forAll ascii $ \x ->
-  let x' = T.decodeUtf8 x
-      y = asciiToLower x
-      y' = T.encodeUtf8 $ T.toLower x' in
-  y' === y
-  where
-    ascii = fmap BS.pack . listOf $ choose (0, 127)
+prop_asciiToLower_idempotent :: Property
+prop_asciiToLower_idempotent =
+  gamble arbitrary $ \x ->
+    Char8.asciiToLower (Char8.asciiToLower x) === Char8.asciiToLower x
+
+prop_asciiToLower_text :: Property
+prop_asciiToLower_text =
+  gamble ascii $ \x ->
+    let x' = T.decodeUtf8 x
+        y = Char8.asciiToLower x
+        y' = T.encodeUtf8 $ T.toLower x' in
+    y' === y
+    where
+      ascii = fmap B.pack . listOf $ choose (0, 127)
+
+prop_eq1 :: Property
+prop_eq1 =
+  gamble arbitrary $ \x0 ->
+  gamble arbitrary $ \xs ->
+    (Char8.eq1 x0 xs)
+    ===
+    (Char8.pack [x0] == xs)
+
+prop_eq2 :: Property
+prop_eq2 =
+  gamble arbitrary $ \x0 ->
+  gamble arbitrary $ \x1 ->
+  gamble arbitrary $ \xs ->
+    (Char8.eq2 x0 x1 xs)
+    ===
+    (Char8.pack [x0, x1] == xs)
+
+prop_eq3 :: Property
+prop_eq3 =
+  gamble arbitrary $ \x0 ->
+  gamble arbitrary $ \x1 ->
+  gamble arbitrary $ \x2 ->
+  gamble arbitrary $ \xs ->
+    (Char8.eq3 x0 x1 x2 xs)
+    ===
+    (Char8.pack [x0, x1, x2] == xs)
+
+prop_eq4 :: Property
+prop_eq4 =
+  gamble arbitrary $ \x0 ->
+  gamble arbitrary $ \x1 ->
+  gamble arbitrary $ \x2 ->
+  gamble arbitrary $ \x3 ->
+  gamble arbitrary $ \xs ->
+    (Char8.eq4 x0 x1 x2 x3 xs)
+    ===
+    (Char8.pack [x0, x1, x2, x3] == xs)
+
+prop_eq5 :: Property
+prop_eq5 =
+  gamble arbitrary $ \x0 ->
+  gamble arbitrary $ \x1 ->
+  gamble arbitrary $ \x2 ->
+  gamble arbitrary $ \x3 ->
+  gamble arbitrary $ \x4 ->
+  gamble arbitrary $ \xs ->
+    (Char8.eq5 x0 x1 x2 x3 x4 xs)
+    ===
+    (Char8.pack [x0, x1, x2, x3, x4] == xs)
 
 return []
 tests :: IO Bool

--- a/x-bytestring/test/test.hs
+++ b/x-bytestring/test/test.hs
@@ -1,11 +1,13 @@
 import           Disorder.Core.Main
 
+import qualified Test.X.Data.ByteString
 import qualified Test.X.Data.ByteString.Char8
 import qualified Test.X.Data.ByteString.Unsafe
 
 main :: IO ()
 main =
   disorderMain [
-      Test.X.Data.ByteString.Char8.tests
+      Test.X.Data.ByteString.tests
+    , Test.X.Data.ByteString.Char8.tests
     , Test.X.Data.ByteString.Unsafe.tests
     ]


### PR DESCRIPTION
After the improvement we saw in https://github.com/ambiata/excel/pull/52 I thought it would be useful to make this kind of equality in to a library.

I have verified that with constant arguments GHC generates perfect constant folded code, so the code below desugars to a comparison with a constant `Word32`, followed by a a comparison with a constant `Word8`:
```hs
X.Data.ByteString.Char8.eq5 'f' 'a' 'l' 's' 'e'
```

Ideally we can update the excel PR with these combinators to it's easier to understand.

! @nhibberd @amosr 