### PR TITLE
X.Data.Vector.Generic.uncons cleanup

### DIFF
--- a/x-vector/src/X/Data/Vector.hs
+++ b/x-vector/src/X/Data/Vector.hs
@@ -79,3 +79,4 @@ merge =
 uncons :: Vector a -> Maybe (a, Vector a)
 uncons =
   Generic.uncons
+{-# INLINE uncons #-}

--- a/x-vector/src/X/Data/Vector/Generic.hs
+++ b/x-vector/src/X/Data/Vector/Generic.hs
@@ -162,9 +162,11 @@ lengths =
 {-# INLINE lengths #-}
 
 uncons :: Vector v a => v a -> Maybe (a, v a)
-uncons v
- = let (pre,post) = splitAt 1 v
-   in  (,) <$> (pre !? 0) <*> pure post
+uncons v =
+  if Generic.null v then
+    Nothing
+  else
+    Just (Generic.unsafeHead v, Generic.unsafeTail v)
 {-# INLINE uncons #-}
 
 data IdxOff =

--- a/x-vector/src/X/Data/Vector/Primitive.hs
+++ b/x-vector/src/X/Data/Vector/Primitive.hs
@@ -81,3 +81,4 @@ merge =
 uncons :: Prim a => Vector a -> Maybe (a, Vector a)
 uncons =
   Generic.uncons
+{-# INLINE uncons #-}

--- a/x-vector/src/X/Data/Vector/Storable.hs
+++ b/x-vector/src/X/Data/Vector/Storable.hs
@@ -80,3 +80,4 @@ merge =
 uncons :: Storable a => Vector a -> Maybe (a, Vector a)
 uncons =
   Generic.uncons
+{-# INLINE uncons #-}

--- a/x-vector/src/X/Data/Vector/Unboxed.hs
+++ b/x-vector/src/X/Data/Vector/Unboxed.hs
@@ -80,3 +80,4 @@ merge =
 uncons :: Unbox a => Vector a -> Maybe (a, Vector a)
 uncons =
   Generic.uncons
+{-# INLINE uncons #-}


### PR DESCRIPTION
I was just reading this code and noticed `uncons` is doing more work than necessary, which bugged me because I use it all the time.

I also noticed there was no `INLINE` pragmas on the specialised version, so I've added them.

! @amosr @nhibberd 
/jury approved @amosr