### PR TITLE
Widen bounds for optparse-applicative to include 0.14

### DIFF
--- a/x-optparse/ambiata-x-optparse.cabal
+++ b/x-optparse/ambiata-x-optparse.cabal
@@ -15,7 +15,7 @@ library
                        base                            >= 3          && < 5
                      , ambiata-p
                      , attoparsec                      >= 0.12       && < 0.14
-                     , optparse-applicative            >= 0.11       && < 0.14
+                     , optparse-applicative            >= 0.11       && < 0.15
                      , text                            == 1.2.*
                      , transformers                    >= 0.4        && < 0.6
 

--- a/x-optparse/ambiata-x-optparse.lock-7.10.2
+++ b/x-optparse/ambiata-x-optparse.lock-7.10.2
@@ -12,7 +12,7 @@ hashable == 1.2.4.0
 ieee754 == 0.7.9
 old-locale == 1.0.0.7
 old-time == 1.1.0.3
-optparse-applicative == 0.13.0.0
+optparse-applicative == 0.14.0.0
 primitive == 0.6.1.0
 QuickCheck == 2.8.2
 quickcheck-instances == 0.3.12


### PR DESCRIPTION
?
! @HuwCampbell @jystic 
/jury approved @jystic